### PR TITLE
Persistent library, filter chips, hide flow, and HLS proxy fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,16 @@
 - fast loading speed (most videos load in 3s)
 - livestream support
 - minimalistic UI, configurable theme color
-- paste video URL / type search query / auto pasting from clipboard
+- persistent library on the home page with thumbnails, titles, durations, and per-video metadata
+- filter the library by **site**, **tags**, and **categories** (populated from source metadata when available) plus live text search
+- hide individual videos or entire source sites, with a "Show hidden" toggle to bring them back
+- paste video URL, type to filter the library, or auto-fill from clipboard
 - zoom to fill for all devices
 - download, repeat videos
 - optional music visualizer
 - browser extension
 - PWA
+- live log viewer at `/logs` and a per-video debug panel on `/watch` pages
 
 
 some of these features are off by default and need to be turned on in `.env`
@@ -60,6 +64,20 @@ some of these features are off by default and need to be turned on in `.env`
     </td>
   </tr>
 </table>
+
+
+## Library
+
+Every video you play is saved by default, so it stays available on your next visit.
+
+- The home page **is** your library: a thumbnail grid with title, duration, and uploader, grouped by source site
+- Filter chips at the top let you narrow down by **sites**, **categories**, and **tags**. Categories and tags are populated from the source's metadata whenever it exposes them; sites that don't just show up under their domain
+- Multiple filter chips combine (AND), and the URL/search bar filters on top of the chip selection
+- If the source doesn't report a duration, the app runs ffprobe on the downloaded media and writes the real duration back into the local meta so the library display stays accurate
+- **Hide** button (eye-slash) on each card removes it from the default view without deleting anything on disk. The button on a site chip hides every video from that site at once
+- **Show hidden** in the header toggles the view to include hidden items with an unhide affordance
+- The library is stored in SQLite (`data/library.db`) and updated automatically when you play or download a video. The **Rebuild** button walks the data folder and re-syncs the whole table — useful if you manually add or remove files
+- Everything (cache, library DB, `.env`, `cookies.txt`) lives under `DATA_PATH` (default `./data`). Set `SAVE_ALL=false` if you want the old behavior where videos auto-expire after `MAX_VIDEO_AGE` seconds
 
 
 ## Planned
@@ -102,13 +120,7 @@ OR
 - Clone repo
 - Run `docker compose up`
 - For automatic app updates, see `compose.yml`
-- To enable environment:
-    - Uncomment:
-        ```
-        # env_file:
-        #     - src/.env
-        ```
-    - Copy `src/example.env` to `src/.env`, modify as needed
+- To configure via environment: copy `src/example.env` to `data/.env`, modify as needed. The file is loaded automatically from the mounted data folder — no compose changes required
 - To enable HTTPS, see `compose.yml`
   - then you can access the HTTPS app with https://localhost:5001
   - your browser will warn you about not secure connection, you need to click on "allow"
@@ -118,15 +130,14 @@ OR
 - Create and activate a virtual environment in `src/` and install `requirements.txt`
 - optionally install `ffmpeg` and `node`/`deno`, otherwise they will be automatically installed to your venv
 - run `main.py`
-- To enable environment:
-    - Copy `src/example.env` to `src/.env`, modify as needed
+- To configure via environment: copy `src/example.env` to `data/.env`, modify as needed (the `data/` folder is created on first run)
 
 
 ## Cookies
 
 Some videos need cookies to work. With cookies you will be logged in to the video streaming's website while using the app.
 
-- Create `src/cookies.txt` file and enable in `compose.yml` (if using docker)
+- Create `data/cookies.txt` (the folder is auto-mounted into the container — no compose changes required)
 - Paste relevant cookies into that file (I suggest using an extension for that, which exports cookies in netscape format)
     - yt-dlp created a nice [guide](https://github.com/yt-dlp/yt-dlp/wiki/FAQ#how-do-i-pass-cookies-to-yt-dlp) about providing the cookies
 - If using extension, you can enable automatic sending of browser cookies for individual videos in extension settings
@@ -200,6 +211,10 @@ Please check if it's supported by yt-dlp [here](https://github.com/yt-dlp/yt-dlp
 Also check [yt-dlp's issues](https://github.com/yt-dlp/yt-dlp/issues).
 
 You can even try to download yt-dlp and download that video with it, to ensure there is a way to download it.
+
+For debugging locally:
+- open `/logs` in the running app to see live stdout/stderr from all workers
+- expand the **Debug info** panel on any `/watch` page to see the source URL, its SHA1 hash (used as the data-dir name), the metadata highlights extracted by yt-dlp, and the files currently on disk. There's also a link to the raw `meta.json`
 
 If it appears to be supported, fill in a bug report with app logs.
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,12 +1,10 @@
 services:
     ytdlp_web_player:
-        # build: .
-        image: matszwe02/ytdlp_web_player:stable
-        # volumes:
-        #     - ./src/cookies.txt:/app/cookies.txt
+        build: .
+        #image: matszwe02/ytdlp_web_player:stable
+        volumes:
+            - ./data:/app/data
         restart: unless-stopped
-        # env_file:
-        #     - src/.env
         ports:
             - 5000:5000
 

--- a/src/addons.py
+++ b/src/addons.py
@@ -20,8 +20,64 @@ from flask import Response, jsonify, request, send_file
 from external import External
 from main import *
 from sb import SponsorBlock
+import library_db
 
 yt_dlp = External.yt_dlp()
+
+
+def backfill_duration(url):
+    """If meta.duration is missing but we have a local media file, ffprobe it and update meta.json."""
+    if not url: return None
+    meta_file = check_media(url, 'meta')
+    if not meta_file: return None
+    try:
+        with open(meta_file, 'r') as f:
+            meta = json.load(f)
+    except Exception:
+        return None
+    if meta.get('duration'): return meta['duration']
+
+    data_dir = get_data_dir(url)
+    try:
+        candidates = os.listdir(data_dir)
+    except OSError:
+        return None
+    probe_file = None
+    for name in sorted(candidates, reverse=True):
+        if not (name.startswith('video-') or name.startswith('audio.') or name.startswith('audio-') or name.startswith('low.')): continue
+        if name.endswith(('.temp', '.part', '.ytdl')): continue
+        ext = os.path.splitext(name)[1].lower()
+        if ext not in ('.mp4', '.webm', '.mkv', '.mp3', '.m4a', '.opus', '.ogg', '.wav'): continue
+        probe_file = os.path.join(data_dir, name)
+        break
+    if not probe_file: return None
+
+    try:
+        duration = get_media_duration(url, {}, probe_file)
+    except Exception as e:
+        pprint_exc(e)
+        return None
+    if not duration: return None
+    meta['duration'] = duration
+    try:
+        with open(meta_file, 'w') as f:
+            json.dump(meta, f)
+        print(f'[duration-backfill] {url} -> {duration:.2f}s (from {os.path.basename(probe_file)})')
+    except Exception as e:
+        pprint_exc(e)
+    return duration
+
+
+def post_media_hooks(url, media_type=None):
+    """Fire-and-forget hooks: backfill missing duration + library upsert. Both idempotent."""
+    try:
+        backfill_duration(url)
+    except Exception as e:
+        pprint_exc(e)
+    try:
+        library_db.sync_url(url)
+    except Exception as e:
+        pprint_exc(e)
 
 
 class FileCachingLock:
@@ -278,7 +334,9 @@ class MediaDownloader:
 
     def run(self):
         with FileCachingLock(self.url, self.media_type) as cache:
-            if cache: return cache
+            if cache:
+                Thread(target=post_media_hooks, args=(self.url, self.media_type), daemon=True).start()
+                return cache
             self._load_variables()
             if   self.media_type.startswith('thumb'): self.thumb()
             elif self.media_type.startswith('playlist'): self.playlist()
@@ -289,7 +347,9 @@ class MediaDownloader:
             elif self.media_type.startswith('low'): self.low()
             elif self.media_type.startswith('sub'): self.sub()
             elif self.media_type.startswith('sprite'): self.sprite()
-        return check_media(url=self.url, media_type=self.media_type)
+        result = check_media(url=self.url, media_type=self.media_type)
+        Thread(target=post_media_hooks, args=(self.url, self.media_type), daemon=True).start()
+        return result
 
 
     def _load_variables(self):
@@ -674,7 +734,12 @@ def stream_media_file(url: str, headers: str|None = None, cookies: str|None = No
         response.raise_for_status()
         mime_type = response.headers.get('Content-Type', 'application/octet-stream')
 
-        if 'mpegurl' in mime_type.lower():
+        url_path = urlparse(url).path.lower()
+        is_hls = 'mpegurl' in mime_type.lower() or url_path.endswith('.m3u8') or url_path.endswith('.m3u')
+        if is_hls and 'mpegurl' not in mime_type.lower():
+            print(f'HLS detected by URL suffix despite Content-Type: {mime_type}  (url={url[:120]}...)')
+
+        if is_hls:
             lines = []
             url_regex = re.compile(r'(URI=["\'])([^"\']*)(["\'])')
 
@@ -702,7 +767,7 @@ def stream_media_file(url: str, headers: str|None = None, cookies: str|None = No
                 else:
                     lines.append(f'/external?url={quote_plus(urljoin(url, line_str))}&headers={quote_plus(headers)}&cookies={quote_plus(cookies)}')
 
-            resp = Response('\n'.join(lines), status=response.status_code, mimetype=mime_type)
+            resp = Response('\n'.join(lines), status=response.status_code, mimetype='application/vnd.apple.mpegurl')
             return resp
 
         def generate():
@@ -837,7 +902,8 @@ def get_data_dir(url):
 
 def get_global_cookies_file(force = False):
     if cookies_only_on_failure and not force: return None
-    if os.path.exists('cookies.txt'): return 'cookies.txt'
+    path = os.path.join(data_path, 'cookies.txt')
+    if os.path.exists(path): return path
     return None
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -1,4 +1,6 @@
 import os
+import json
+import shutil
 import signal
 import sys
 from flask import Flask, render_template, request, jsonify, Response
@@ -8,6 +10,11 @@ from starlette.middleware.wsgi import WSGIMiddleware
 from main import *
 from addons import *
 from external import External
+import library_db
+import log_capture
+
+log_capture.init(os.path.join(data_path, 'app.log'))
+library_db.init_db()
 
 
 app = Flask(__name__)
@@ -22,14 +29,123 @@ signal.signal(signal.SIGINT, signal_handler)
 signal.signal(signal.SIGTERM, signal_handler)
 
 
-@app.route('/')
-def index():
-    print('Started serving root')
+def _render_home():
+    print('Started serving home/library')
+    show_hidden = request.args.get('show_hidden') in ('1', 'true', 'yes')
     ydl_version = External.get_ytdlp_version()
     js_runtime_version = External.get_js_runtime_version(js_runtime)
     ffmpeg_version = External.get_ffmpeg_version(ffmpeg)
-    print('Stopped serving root')
-    return render_template('index.html', ydl_version=ydl_version, app_version=app_version, js_runtime_version=js_runtime_version, ffmpeg_version=ffmpeg_version, app_title=app_title, theme_color=theme_color, amoled_bg=amoled_bg)
+    entries = library_db.list_videos(include_hidden=show_hidden)
+    grouped = {}
+    for e in entries:
+        grouped.setdefault(e.get('source_site') or 'unknown', []).append(e)
+    grouped = dict(sorted(grouped.items(), key=lambda kv: kv[0]))
+    all_tags = library_db.list_tags(include_hidden=show_hidden)
+    all_categories = library_db.list_categories(include_hidden=show_hidden)
+    all_sites = library_db.list_sites(include_hidden=show_hidden)
+    hidden_sites = library_db.list_hidden_sites()
+    print('Stopped serving home/library')
+    return render_template('index.html',
+        entries=entries, grouped=grouped, total=len(entries),
+        all_tags=all_tags, all_categories=all_categories, all_sites=all_sites,
+        hidden_sites=hidden_sites, show_hidden=show_hidden,
+        ydl_version=ydl_version, app_version=app_version,
+        js_runtime_version=js_runtime_version, ffmpeg_version=ffmpeg_version,
+        app_title=app_title, theme_color=theme_color, amoled_bg=amoled_bg)
+
+
+@app.route('/')
+def index():
+    return _render_home()
+
+
+@app.route('/library')
+def library():
+    return _render_home()
+
+
+@app.route('/library/rebuild', methods=['POST'])
+def library_rebuild():
+    try:
+        count = library_db.rebuild()
+    except Exception as e:
+        return pprint_exc(e)
+    return jsonify({"ok": True, "count": count}), 200
+
+
+@app.route('/library/delete', methods=['POST'])
+def library_delete():
+    url = get_url(request)
+    if not url: return jsonify({"error": "URL parameter is required"}), 400
+    Processes.rm_all(url)
+    vid_dir = get_data_dir(url)
+    library_db.delete_video(url)
+    if not os.path.isdir(vid_dir): return jsonify({"ok": True, "note": "not on disk"}), 200
+    try:
+        shutil.rmtree(vid_dir)
+    except Exception as e:
+        return pprint_exc(e)
+    return jsonify({"ok": True}), 200
+
+
+@app.route('/library/hide', methods=['POST'])
+def library_hide():
+    url = get_url(request)
+    if not url: return jsonify({"error": "URL parameter is required"}), 400
+    library_db.hide_video(url)
+    return jsonify({"ok": True}), 200
+
+
+@app.route('/library/unhide', methods=['POST'])
+def library_unhide():
+    url = get_url(request)
+    if not url: return jsonify({"error": "URL parameter is required"}), 400
+    library_db.unhide_video(url)
+    return jsonify({"ok": True}), 200
+
+
+@app.route('/library/site/hide', methods=['POST'])
+def library_site_hide():
+    name = request.args.get('name', '').strip().lower()
+    if not name: return jsonify({"error": "name parameter is required"}), 400
+    library_db.hide_site(name)
+    return jsonify({"ok": True}), 200
+
+
+@app.route('/library/site/unhide', methods=['POST'])
+def library_site_unhide():
+    name = request.args.get('name', '').strip().lower()
+    if not name: return jsonify({"error": "name parameter is required"}), 400
+    library_db.unhide_site(name)
+    return jsonify({"ok": True}), 200
+
+
+@app.route('/logs')
+def logs_page():
+    return render_template('logs.html', app_title=app_title, theme_color=theme_color, amoled_bg=amoled_bg, log_path=log_capture.LOG_PATH)
+
+
+@app.route('/logs/tail')
+def logs_tail():
+    since = request.args.get('since', type=int)
+    if since is None:
+        data, size = log_capture.read_tail()
+    else:
+        data, size = log_capture.read_since(since)
+    resp = Response(data, mimetype='text/plain; charset=utf-8')
+    resp.headers['X-Log-Size'] = str(size)
+    return resp
+
+
+@app.route('/logs/clear', methods=['POST'])
+def logs_clear():
+    path = log_capture.LOG_PATH
+    if not path: return jsonify({"error": "log capture not initialized"}), 500
+    try:
+        open(path, 'w').close()
+    except Exception as e:
+        return pprint_exc(e)
+    return jsonify({"ok": True}), 200
 
 
 @app.route('/watch')
@@ -43,6 +159,7 @@ def watch():
     video_width = 1280
     video_height = 720
     video_title = app_title
+    meta = None
 
     if check_media(url, 'meta'):
         meta = get_meta(url)
@@ -50,9 +167,69 @@ def watch():
         video_height = meta.get('height') or video_height
         video_title = meta.get('title') or app_title
     preload(url)
+    if url:
+        Thread(target=post_media_hooks, args=(url,), daemon=True).start()
+
+    debug = _watch_debug(url, meta)
 
     print('Stopped serving watch')
-    return render_template('watch.html', original_url=url, ydl_version=ydl_version, app_version=app_version, js_runtime_version=js_runtime_version, ffmpeg_version=ffmpeg_version, app_title=app_title, theme_color=theme_color, amoled_bg=amoled_bg, video_width=video_width, video_height=video_height, video_title=video_title)
+    return render_template('watch.html', original_url=url, ydl_version=ydl_version, app_version=app_version, js_runtime_version=js_runtime_version, ffmpeg_version=ffmpeg_version, app_title=app_title, theme_color=theme_color, amoled_bg=amoled_bg, video_width=video_width, video_height=video_height, video_title=video_title, debug=debug)
+
+
+def _format_size(n):
+    if n is None: return ''
+    step = 1024.0
+    units = ['B', 'KB', 'MB', 'GB', 'TB']
+    i = 0
+    x = float(n)
+    while x >= step and i < len(units) - 1:
+        x /= step
+        i += 1
+    return f'{x:.1f} {units[i]}' if i else f'{int(x)} {units[i]}'
+
+
+def _watch_debug(url, meta):
+    dir_hash = gen_pathname(url) if url else None
+    data_dir = get_data_dir(url) if url else None
+    files = []
+    if data_dir and os.path.isdir(data_dir):
+        for name in sorted(os.listdir(data_dir)):
+            p = os.path.join(data_dir, name)
+            try:
+                if os.path.isdir(p):
+                    files.append({'name': name + '/', 'size': '', 'is_dir': True})
+                else:
+                    files.append({'name': name, 'size': _format_size(os.path.getsize(p)), 'is_dir': False})
+            except OSError:
+                pass
+    highlights = {}
+    if meta:
+        for k in ('extractor', 'extractor_key', 'title', 'uploader', 'uploader_id', 'channel', 'upload_date',
+                  'duration', 'width', 'height', 'fps', 'is_live', 'filesize_approx', 'ext', 'protocol', 'language'):
+            v = meta.get(k)
+            if v is not None and v != '':
+                highlights[k] = v
+    return {
+        'url': url,
+        'dir_hash': dir_hash,
+        'data_dir': data_dir,
+        'files': files,
+        'meta_highlights': highlights,
+        'has_meta': meta is not None,
+    }
+
+
+@app.route('/debug/meta')
+def debug_meta():
+    url = get_url(request)
+    if not url: return jsonify({"error": "URL parameter is required"}), 400
+    if not check_media(url, 'meta'): return jsonify({"error": "No meta cached for that URL"}), 404
+    meta = get_meta(url)
+    pretty = request.args.get('pretty', '1') != '0'
+    return Response(
+        json.dumps(meta, indent=2 if pretty else None, default=str),
+        mimetype='application/json'
+    )
 
 
 @app.route('/iframe')
@@ -239,20 +416,6 @@ def hls_segment():
         return jsonify({"error": "File not found"}), 404
 
     return send_file_partial(file)
-
-
-@app.route('/search')
-def serve_search():
-    try:
-        query = request.args.get('q')
-        meta = search(query)[0]
-        url = meta.get('original_url') or ''
-        final_url = append_query_to_url(url, query)
-
-        preload(final_url, meta)
-        return final_url
-    except Exception as e:
-        return pprint_exc(e)
 
 
 @app.route('/cookies', methods=['POST'])

--- a/src/example.env
+++ b/src/example.env
@@ -17,5 +17,6 @@
 # AUTO_BG_PLAYBACK=true # keep playing videos in background after leaving application or locking screen
 # AUDIO_VISUALIZER=false
 # DATA_PATH=./data
+# SAVE_ALL=true # keep every downloaded video permanently (disables MAX_VIDEO_AGE cleanup)
 # PROXY="" # proxy for accessing video sources, e.g. http://127.0.0.1:8888
 # PORT = 5000

--- a/src/library_db.py
+++ b/src/library_db.py
@@ -1,0 +1,372 @@
+import json
+import os
+import sqlite3
+from hashlib import sha1
+from urllib.parse import urlparse
+
+from main import data_path
+
+
+def dir_hash(url):
+    return sha1(url.encode()).hexdigest()
+
+DB_PATH = os.path.join(data_path, 'library.db')
+MEDIA_EXTS = ('.mp4', '.webm', '.mkv', '.mp3', '.m4a', '.opus', '.ogg', '.wav')
+
+
+def _connect():
+    conn = sqlite3.connect(DB_PATH, timeout=10)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def init_db():
+    os.makedirs(data_path, exist_ok=True)
+    with _connect() as conn:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS videos (
+                url TEXT PRIMARY KEY,
+                dir_hash TEXT NOT NULL,
+                title TEXT,
+                uploader TEXT,
+                source_site TEXT,
+                duration INTEGER,
+                width INTEGER,
+                height INTEGER,
+                upload_date TEXT,
+                has_thumb INTEGER,
+                saved_at INTEGER,
+                hidden INTEGER NOT NULL DEFAULT 0
+            )
+        """)
+        existing_cols = {r['name'] for r in conn.execute("PRAGMA table_info(videos)").fetchall()}
+        if 'hidden' not in existing_cols:
+            conn.execute("ALTER TABLE videos ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_videos_source_site ON videos(source_site)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_videos_saved_at ON videos(saved_at)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_videos_hidden ON videos(hidden)")
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS hidden_sites (
+                name TEXT PRIMARY KEY
+            )
+        """)
+
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS tags (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS categories (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS video_tags (
+                url TEXT NOT NULL,
+                tag_id INTEGER NOT NULL,
+                PRIMARY KEY (url, tag_id),
+                FOREIGN KEY (url) REFERENCES videos(url) ON DELETE CASCADE,
+                FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS video_categories (
+                url TEXT NOT NULL,
+                category_id INTEGER NOT NULL,
+                PRIMARY KEY (url, category_id),
+                FOREIGN KEY (url) REFERENCES videos(url) ON DELETE CASCADE,
+                FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE CASCADE
+            )
+        """)
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_video_tags_tag ON video_tags(tag_id)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_video_categories_cat ON video_categories(category_id)")
+
+
+def _clean_labels(items):
+    if not items: return []
+    seen = set()
+    out = []
+    for x in items:
+        if not isinstance(x, str): continue
+        s = x.strip()
+        if not s: continue
+        key = s.lower()
+        if key in seen: continue
+        seen.add(key)
+        out.append(s)
+    return out
+
+
+def _ensure_ids(conn, table, names):
+    ids = []
+    for name in names:
+        row = conn.execute(f"SELECT id FROM {table} WHERE name = ?", (name,)).fetchone()
+        if row:
+            ids.append(row['id'])
+        else:
+            cur = conn.execute(f"INSERT INTO {table} (name) VALUES (?)", (name,))
+            ids.append(cur.lastrowid)
+    return ids
+
+
+def _sync_associations(conn, url, tag_names, cat_names):
+    conn.execute("DELETE FROM video_tags WHERE url = ?", (url,))
+    conn.execute("DELETE FROM video_categories WHERE url = ?", (url,))
+    for tag_id in _ensure_ids(conn, 'tags', tag_names):
+        conn.execute("INSERT OR IGNORE INTO video_tags (url, tag_id) VALUES (?, ?)", (url, tag_id))
+    for cat_id in _ensure_ids(conn, 'categories', cat_names):
+        conn.execute("INSERT OR IGNORE INTO video_categories (url, category_id) VALUES (?, ?)", (url, cat_id))
+
+
+def _prune_orphans(conn):
+    conn.execute("DELETE FROM tags WHERE id NOT IN (SELECT tag_id FROM video_tags)")
+    conn.execute("DELETE FROM categories WHERE id NOT IN (SELECT category_id FROM video_categories)")
+
+
+def _list_labels_for(conn, table_junction, key_col, table_dim):
+    rows = conn.execute(f"""
+        SELECT j.url AS url, d.name AS name
+        FROM {table_junction} j
+        JOIN {table_dim} d ON d.id = j.{key_col}
+    """).fetchall()
+    grouped = {}
+    for r in rows:
+        grouped.setdefault(r['url'], []).append(r['name'])
+    for names in grouped.values():
+        names.sort(key=str.lower)
+    return grouped
+
+
+_VISIBILITY_WHERE = "v.hidden = 0 AND v.source_site NOT IN (SELECT name FROM hidden_sites)"
+
+
+def list_videos(include_hidden=False):
+    with _connect() as conn:
+        hidden_sites = {r['name'] for r in conn.execute("SELECT name FROM hidden_sites").fetchall()}
+        sql = "SELECT v.* FROM videos v"
+        if not include_hidden:
+            sql += " WHERE " + _VISIBILITY_WHERE
+        sql += " ORDER BY v.saved_at DESC"
+        rows = conn.execute(sql).fetchall()
+        videos = [dict(r) for r in rows]
+        tags_map = _list_labels_for(conn, 'video_tags', 'tag_id', 'tags')
+        cats_map = _list_labels_for(conn, 'video_categories', 'category_id', 'categories')
+    for v in videos:
+        v['tags'] = tags_map.get(v['url'], [])
+        v['categories'] = cats_map.get(v['url'], [])
+        v['site_hidden'] = v.get('source_site') in hidden_sites
+    return videos
+
+
+def list_sites(include_hidden=False):
+    with _connect() as conn:
+        hidden_sites = {r['name'] for r in conn.execute("SELECT name FROM hidden_sites").fetchall()}
+        if include_hidden:
+            rows = conn.execute("""
+                SELECT source_site AS name, COUNT(*) AS cnt
+                FROM videos
+                WHERE source_site IS NOT NULL AND source_site != ''
+                GROUP BY source_site
+                ORDER BY cnt DESC, LOWER(source_site)
+            """).fetchall()
+        else:
+            rows = conn.execute(f"""
+                SELECT v.source_site AS name, COUNT(*) AS cnt
+                FROM videos v
+                WHERE v.source_site IS NOT NULL AND v.source_site != ''
+                  AND {_VISIBILITY_WHERE}
+                GROUP BY v.source_site
+                ORDER BY cnt DESC, LOWER(v.source_site)
+            """).fetchall()
+    out = []
+    for r in rows:
+        d = dict(r)
+        d['hidden'] = d['name'] in hidden_sites
+        out.append(d)
+    return out
+
+
+def list_tags(include_hidden=False):
+    join = "" if include_hidden else "JOIN videos v ON v.url = vt.url"
+    where = "" if include_hidden else "WHERE " + _VISIBILITY_WHERE
+    with _connect() as conn:
+        rows = conn.execute(f"""
+            SELECT t.name AS name, COUNT(vt.url) AS cnt
+            FROM tags t
+            JOIN video_tags vt ON vt.tag_id = t.id
+            {join}
+            {where}
+            GROUP BY t.id
+            ORDER BY cnt DESC, LOWER(t.name)
+        """).fetchall()
+    return [dict(r) for r in rows]
+
+
+def list_categories(include_hidden=False):
+    join = "" if include_hidden else "JOIN videos v ON v.url = vc.url"
+    where = "" if include_hidden else "WHERE " + _VISIBILITY_WHERE
+    with _connect() as conn:
+        rows = conn.execute(f"""
+            SELECT c.name AS name, COUNT(vc.url) AS cnt
+            FROM categories c
+            JOIN video_categories vc ON vc.category_id = c.id
+            {join}
+            {where}
+            GROUP BY c.id
+            ORDER BY cnt DESC, LOWER(c.name)
+        """).fetchall()
+    return [dict(r) for r in rows]
+
+
+def hide_video(url):
+    with _connect() as conn:
+        conn.execute("UPDATE videos SET hidden = 1 WHERE url = ?", (url,))
+
+
+def unhide_video(url):
+    with _connect() as conn:
+        conn.execute("UPDATE videos SET hidden = 0 WHERE url = ?", (url,))
+
+
+def hide_site(name):
+    if not name: return
+    with _connect() as conn:
+        conn.execute("INSERT OR IGNORE INTO hidden_sites (name) VALUES (?)", (name,))
+
+
+def unhide_site(name):
+    if not name: return
+    with _connect() as conn:
+        conn.execute("DELETE FROM hidden_sites WHERE name = ?", (name,))
+
+
+def list_hidden_sites():
+    with _connect() as conn:
+        rows = conn.execute("SELECT name FROM hidden_sites ORDER BY LOWER(name)").fetchall()
+    return [r['name'] for r in rows]
+
+
+def delete_video(url):
+    with _connect() as conn:
+        conn.execute("DELETE FROM videos WHERE url = ?", (url,))
+        _prune_orphans(conn)
+
+
+def source_site(url):
+    try:
+        netloc = urlparse(url).netloc.lower()
+        return netloc.removeprefix('www.') or 'unknown'
+    except Exception:
+        return 'unknown'
+
+
+def _has_media(vid_dir):
+    for f in os.listdir(vid_dir):
+        if not (f.startswith('video-') or f.startswith('audio.') or f.startswith('audio-') or f.startswith('low.')):
+            continue
+        if f.endswith(('.temp', '.part', '.ytdl')):
+            continue
+        if os.path.splitext(f)[1].lower() in MEDIA_EXTS:
+            return True
+    return False
+
+
+def _row_from_meta(url, name, vid_dir, meta):
+    return (
+        url,
+        name,
+        meta.get('title') or url,
+        meta.get('uploader') or '',
+        source_site(url),
+        int(meta.get('duration') or 0),
+        meta.get('width'),
+        meta.get('height'),
+        meta.get('upload_date') or '',
+        1 if os.path.exists(os.path.join(vid_dir, 'thumb.jpg')) else 0,
+        int(os.path.getmtime(os.path.join(vid_dir, 'meta.json'))),
+    )
+
+
+def _upsert_with_meta(conn, row, tag_names, cat_names):
+    url = row[0]
+    conn.execute("""
+        INSERT INTO videos (url, dir_hash, title, uploader, source_site, duration, width, height, upload_date, has_thumb, saved_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(url) DO UPDATE SET
+            dir_hash=excluded.dir_hash,
+            title=excluded.title,
+            uploader=excluded.uploader,
+            source_site=excluded.source_site,
+            duration=excluded.duration,
+            width=excluded.width,
+            height=excluded.height,
+            upload_date=excluded.upload_date,
+            has_thumb=excluded.has_thumb,
+            saved_at=excluded.saved_at
+    """, row)
+    _sync_associations(conn, url, tag_names, cat_names)
+
+
+def sync_url(url):
+    """Upsert (or delete) a single URL's library row based on what's on disk. Idempotent."""
+    if not url: return None
+    name = dir_hash(url)
+    vid_dir = os.path.join(data_path, name)
+    meta_path = os.path.join(vid_dir, 'meta.json')
+    if not os.path.isdir(vid_dir) or not os.path.exists(meta_path) or not _has_media(vid_dir):
+        delete_video(url)
+        return None
+    try:
+        with open(meta_path, 'r') as fh:
+            meta = json.load(fh)
+    except Exception:
+        return None
+    if not (meta.get('original_url') or url): return None
+    tags = _clean_labels(meta.get('tags'))
+    cats = _clean_labels(meta.get('categories'))
+    with _connect() as conn:
+        _upsert_with_meta(conn, _row_from_meta(url, name, vid_dir, meta), tags, cats)
+        _prune_orphans(conn)
+    return url
+
+
+def rebuild():
+    entries = []
+    try:
+        dir_names = os.listdir(data_path)
+    except FileNotFoundError:
+        dir_names = []
+    for name in dir_names:
+        vid_dir = os.path.join(data_path, name)
+        if not os.path.isdir(vid_dir): continue
+        meta_path = os.path.join(vid_dir, 'meta.json')
+        if not os.path.exists(meta_path): continue
+        if not _has_media(vid_dir): continue
+        try:
+            with open(meta_path, 'r') as fh:
+                meta = json.load(fh)
+        except Exception:
+            continue
+        url = meta.get('original_url') or ''
+        if not url: continue
+        entries.append((
+            _row_from_meta(url, name, vid_dir, meta),
+            _clean_labels(meta.get('tags')),
+            _clean_labels(meta.get('categories')),
+        ))
+    with _connect() as conn:
+        hidden_urls = {r['url'] for r in conn.execute("SELECT url FROM videos WHERE hidden = 1").fetchall()}
+        conn.execute("DELETE FROM video_tags")
+        conn.execute("DELETE FROM video_categories")
+        conn.execute("DELETE FROM tags")
+        conn.execute("DELETE FROM categories")
+        conn.execute("DELETE FROM videos")
+        for row, tags, cats in entries:
+            _upsert_with_meta(conn, row, tags, cats)
+        if hidden_urls:
+            conn.executemany("UPDATE videos SET hidden = 1 WHERE url = ?", [(u,) for u in hidden_urls])
+    return len(entries)

--- a/src/log_capture.py
+++ b/src/log_capture.py
@@ -1,0 +1,98 @@
+import os
+import sys
+from threading import Lock
+
+_MAX_BYTES = 10 * 1024 * 1024
+_lock = Lock()
+LOG_PATH = None
+
+
+class _Tee:
+    def __init__(self, original, path):
+        self._original = original
+        self._path = path
+
+    def write(self, s):
+        try:
+            self._original.write(s)
+        except Exception:
+            pass
+        if not s or LOG_PATH is None:
+            return
+        try:
+            with _lock:
+                try:
+                    size = os.path.getsize(self._path)
+                except FileNotFoundError:
+                    size = 0
+                if size > _MAX_BYTES:
+                    try:
+                        with open(self._path, 'rb') as f:
+                            f.seek(-_MAX_BYTES // 2, 2)
+                            tail = f.read()
+                        with open(self._path, 'wb') as f:
+                            f.write(tail)
+                    except Exception:
+                        pass
+                with open(self._path, 'a', encoding='utf-8', errors='replace') as f:
+                    f.write(s)
+        except Exception:
+            pass
+
+    def flush(self):
+        try:
+            self._original.flush()
+        except Exception:
+            pass
+
+    def isatty(self):
+        try:
+            return self._original.isatty()
+        except Exception:
+            return False
+
+    def fileno(self):
+        return self._original.fileno()
+
+    def __getattr__(self, name):
+        return getattr(self._original, name)
+
+
+def init(path):
+    global LOG_PATH
+    LOG_PATH = path
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    open(path, 'a').close()
+    if not isinstance(sys.stdout, _Tee):
+        sys.stdout = _Tee(sys.stdout, path)
+    if not isinstance(sys.stderr, _Tee):
+        sys.stderr = _Tee(sys.stderr, path)
+
+
+def read_since(offset):
+    if LOG_PATH is None or not os.path.exists(LOG_PATH):
+        return b'', 0
+    try:
+        size = os.path.getsize(LOG_PATH)
+    except OSError:
+        return b'', 0
+    if offset > size:
+        offset = 0
+    with open(LOG_PATH, 'rb') as f:
+        f.seek(offset)
+        data = f.read()
+    return data, size
+
+
+def read_tail(max_bytes=64 * 1024):
+    if LOG_PATH is None or not os.path.exists(LOG_PATH):
+        return b'', 0
+    try:
+        size = os.path.getsize(LOG_PATH)
+    except OSError:
+        return b'', 0
+    start = max(0, size - max_bytes)
+    with open(LOG_PATH, 'rb') as f:
+        f.seek(start)
+        data = f.read()
+    return data, size

--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,7 @@ os.chdir(os.path.dirname(__file__))
 
 print('Loading configuration from environment, env file and command line arguments')
 
-load_dotenv()
+load_dotenv(dotenv_path=os.path.join('data', '.env'), override=False)
 
 for arg in sys.argv[1:]:
     if arg.startswith('-') and '=' in arg:
@@ -35,6 +35,7 @@ playlist_support = os.environ.get('PLAYLIST_SUPPORT', 'True').lower() == 'true'
 auto_bg_playback = os.environ.get('AUTO_BG_PLAYBACK', 'True').lower() == 'true'
 audio_visualizer = os.environ.get('AUDIO_VISUALIZER', 'False').lower() == 'true'
 data_path = os.path.abspath(os.environ.get('DATA_PATH', './data'))
+save_all = os.environ.get('SAVE_ALL', 'True').lower() == 'true'
 proxy = os.environ.get('PROXY', '')
 port = int(os.environ.get('PORT', '5000'))
 
@@ -71,6 +72,9 @@ def ytdlp_download():
 
 def delete_old_files():
     while True:
+        if save_all:
+            time.sleep(max_video_age)
+            continue
         print(f"Running periodic removal of old files")
         try:
             for item_name in os.listdir(data_path):

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -793,3 +793,737 @@ video
         height: 70px;
     }
 }
+
+
+body.library-body
+{
+    display: block;
+    height: auto;
+    min-height: 100vh;
+}
+
+.library-page
+{
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 24px 24px 80px;
+}
+
+.library-header
+{
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    margin-bottom: 24px;
+}
+
+.library-header h1
+{
+    margin: 0;
+    font-size: 28px;
+    flex: 1;
+}
+
+.library-home
+{
+    color: white;
+    text-decoration: none;
+    font-size: 20px;
+    width: 40px;
+    height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background-color: var(--theme-bg-light);
+}
+
+.library-home:hover
+{
+    background-color: #333;
+}
+
+.library-count
+{
+    color: var(--theme-fg);
+    font-size: 14px;
+}
+
+.library-empty
+{
+    color: var(--theme-fg);
+    text-align: center;
+    margin-top: 80px;
+    font-size: 16px;
+}
+
+.library-grid
+{
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 20px;
+}
+
+.library-card
+{
+    background-color: var(--theme-bg-light);
+    border-radius: 8px;
+    overflow: hidden;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    transition: transform 0.15s ease-out;
+}
+
+.library-card:hover
+{
+    transform: translateY(-2px);
+}
+
+.library-thumb-link
+{
+    display: block;
+    text-decoration: none;
+    color: inherit;
+}
+
+.library-thumb-wrap
+{
+    position: relative;
+    aspect-ratio: 16 / 9;
+    background-color: #000;
+    overflow: hidden;
+}
+
+.library-thumb-wrap img
+{
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.library-thumb-fallback
+{
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--theme-fg);
+    font-size: 42px;
+}
+
+.library-duration
+{
+    position: absolute;
+    right: 8px;
+    bottom: 8px;
+    background-color: rgba(0, 0, 0, 0.8);
+    color: white;
+    font-size: 12px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-variant-numeric: tabular-nums;
+}
+
+.library-meta
+{
+    padding: 10px 12px 14px;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.library-title
+{
+    color: white;
+    text-decoration: none;
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.library-title:hover
+{
+    color: #ddd;
+}
+
+.library-uploader
+{
+    color: var(--theme-fg);
+    font-size: 12px;
+}
+
+.library-hide
+{
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    width: 32px;
+    height: 32px;
+    border: none;
+    background-color: rgba(0, 0, 0, 0.7);
+    color: white;
+    border-radius: 50%;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.15s ease-out, background-color 0.15s ease-out;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+}
+
+.library-card:hover .library-hide,
+.library-hide:focus,
+.is-hidden-card .library-hide
+{
+    opacity: 1;
+}
+
+.library-hide:hover
+{
+    background-color: #444;
+}
+
+.library-hide:disabled
+{
+    opacity: 0.5;
+    cursor: wait;
+}
+
+.is-hidden-card
+{
+    opacity: 0.45;
+    filter: grayscale(60%);
+}
+
+.is-hidden-card:hover
+{
+    opacity: 0.85;
+    filter: grayscale(0%);
+}
+
+.chip-wrap
+{
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+}
+
+.chip-hide-toggle
+{
+    background-color: rgba(0, 0, 0, 0.6);
+    border: 1px solid #333;
+    color: #ccc;
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    margin-left: -8px;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: 10px;
+    position: relative;
+    z-index: 1;
+}
+
+.chip-wrap:hover .chip-hide-toggle,
+.chip-hide-toggle[data-hidden="1"]
+{
+    display: inline-flex;
+}
+
+.chip-hide-toggle:hover
+{
+    color: white;
+    background-color: #444;
+}
+
+.chip.chip-is-hidden
+{
+    opacity: 0.55;
+    text-decoration: line-through;
+}
+
+
+.home-header
+{
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 32px;
+}
+
+.home-title-row
+{
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    flex-wrap: wrap;
+}
+
+.home-logo
+{
+    height: 42px;
+    width: 42px;
+}
+
+.home-title-row h1
+{
+    margin: 0;
+    font-size: 26px;
+    flex: 0 1 auto;
+}
+
+.home-title-row .library-count
+{
+    flex: 1;
+}
+
+.library-rebuild
+{
+    background-color: var(--theme-bg-light);
+    color: white;
+    border: 1px solid #333;
+    border-radius: 6px;
+    padding: 8px 14px;
+    font-size: 14px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    transition: background-color 0.15s ease-out, border-color 0.15s ease-out;
+}
+
+.library-rebuild:hover
+{
+    background-color: #333;
+    border-color: #444;
+}
+
+.library-rebuild:disabled
+{
+    opacity: 0.6;
+    cursor: wait;
+}
+
+.home-url-bar
+{
+    display: flex;
+    height: 46px;
+    border-radius: 23px;
+    background-color: #aaa;
+    overflow: hidden;
+    width: 100%;
+    max-width: 700px;
+}
+
+.home-url-bar #url
+{
+    flex: 1;
+    border: none;
+    padding: 0 18px;
+    font-size: 15pt;
+    background-color: transparent;
+    color: black;
+    outline: none;
+}
+
+.home-url-bar #submit
+{
+    width: 50px;
+    border: none;
+    background-color: transparent;
+    color: black;
+    font-size: 1.3em;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.15s ease-out;
+}
+
+.home-url-bar #submit:hover
+{
+    background-color: #999;
+}
+
+.library-section
+{
+    margin-bottom: 40px;
+}
+
+.library-section-title
+{
+    color: white;
+    font-size: 18px;
+    margin: 0 0 14px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid #333;
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    text-transform: none;
+}
+
+.library-section-count
+{
+    color: var(--theme-fg);
+    font-size: 13px;
+    font-weight: normal;
+}
+
+@media only screen and (max-width: 600px)
+{
+    .home-title-row h1
+    {
+        font-size: 20px;
+    }
+    .home-logo
+    {
+        height: 32px;
+        width: 32px;
+    }
+    .library-grid
+    {
+        grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+        gap: 12px;
+    }
+}
+
+
+.filter-chips
+{
+    margin-bottom: 24px;
+    padding: 12px 14px;
+    background-color: var(--theme-bg-light);
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.filter-row,
+.filter-active-row
+{
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    flex-wrap: nowrap;
+}
+
+.filter-label
+{
+    color: var(--theme-fg);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding-top: 4px;
+    min-width: 76px;
+    flex: 0 0 auto;
+}
+
+.chips
+{
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    flex: 1;
+}
+
+.chip
+{
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 10px;
+    border: 1px solid #333;
+    border-radius: 999px;
+    background-color: #202020;
+    color: #ddd;
+    font-size: 12px;
+    cursor: pointer;
+    line-height: 1.7;
+    white-space: nowrap;
+    transition: background-color 0.15s ease-out, border-color 0.15s ease-out;
+    font-family: inherit;
+}
+
+.chip:hover
+{
+    background-color: #2b2b2b;
+    border-color: #555;
+}
+
+.chip.active
+{
+    background-color: #3b5998;
+    border-color: #5378c0;
+    color: white;
+}
+
+.chip-site
+{
+    border-color: #4a3b6b;
+}
+
+.chip-site.active
+{
+    background-color: #6b3fb5;
+    border-color: #8a5fd8;
+}
+
+.chip-cat
+{
+    border-color: #2c4a6b;
+}
+
+.chip-cat.active
+{
+    background-color: #2c6cc0;
+    border-color: #4f8ee0;
+}
+
+.chip-tag
+{
+    color: #ccc;
+}
+
+.chip-count
+{
+    color: var(--theme-fg);
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+}
+
+.chip.active .chip-count
+{
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.chip-active
+{
+    background-color: #2c6cc0;
+    border-color: #4f8ee0;
+    color: white;
+}
+
+.chip-active .fa-xmark
+{
+    font-size: 11px;
+    opacity: 0.85;
+}
+
+.chip-clear
+{
+    background: none;
+    border: none;
+    color: var(--theme-fg);
+    font-size: 12px;
+    cursor: pointer;
+    padding: 4px 8px;
+    align-self: center;
+}
+
+.chip-clear:hover
+{
+    color: white;
+}
+
+.chip-more-toggle
+{
+    color: var(--theme-fg);
+    border-style: dashed;
+}
+
+.chip-sm
+{
+    padding: 1px 8px;
+    font-size: 11px;
+}
+
+.card-chips
+{
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-top: 6px;
+}
+
+.chip-more
+{
+    color: var(--theme-fg);
+    font-size: 11px;
+    padding: 2px 6px;
+    cursor: default;
+}
+
+
+.watch-debug
+{
+    position: fixed;
+    bottom: 12px;
+    left: 12px;
+    max-width: min(720px, calc(100vw - 24px));
+    max-height: 70vh;
+    overflow: auto;
+    background-color: rgba(20, 20, 20, 0.94);
+    color: #ddd;
+    border: 1px solid #333;
+    border-radius: 6px;
+    font-size: 12px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    z-index: 100;
+}
+
+.watch-debug summary
+{
+    padding: 8px 12px;
+    cursor: pointer;
+    color: white;
+    font-family: Verdana, Geneva, Tahoma, sans-serif;
+    user-select: none;
+}
+
+.watch-debug summary i
+{
+    margin-right: 6px;
+}
+
+.watch-debug-body
+{
+    padding: 4px 12px 12px;
+    border-top: 1px solid #333;
+}
+
+.watch-debug h4
+{
+    margin: 12px 0 6px;
+    font-family: Verdana, Geneva, Tahoma, sans-serif;
+    font-size: 12px;
+    color: var(--theme-fg);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.watch-debug table
+{
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.watch-debug th
+{
+    text-align: left;
+    padding: 3px 8px 3px 0;
+    color: var(--theme-fg);
+    font-weight: normal;
+    white-space: nowrap;
+    vertical-align: top;
+    width: 1%;
+}
+
+.watch-debug td
+{
+    padding: 3px 0;
+    word-break: break-all;
+}
+
+.watch-debug code
+{
+    color: #eee;
+    font-family: inherit;
+}
+
+.watch-debug a
+{
+    color: #6bf;
+}
+
+
+.logs-body
+{
+    display: block;
+    height: auto;
+    min-height: 100vh;
+    background-color: #0e0e0e;
+}
+
+.logs-page
+{
+    max-width: 100%;
+    padding: 12px 16px 32px;
+    color: #ddd;
+}
+
+.logs-toolbar
+{
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #222;
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+}
+
+.logs-toolbar h1
+{
+    margin: 0;
+    font-size: 18px;
+    flex: 0 1 auto;
+}
+
+.logs-toolbar label
+{
+    color: var(--theme-fg);
+    font-size: 13px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.logs-toolbar button
+{
+    background-color: var(--theme-bg-light);
+    color: white;
+    border: 1px solid #333;
+    padding: 6px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 13px;
+}
+
+.logs-toolbar button:hover
+{
+    background-color: #333;
+}
+
+.logs-status
+{
+    color: var(--theme-fg);
+    font-size: 12px;
+    margin-left: auto;
+    font-variant-numeric: tabular-nums;
+}
+
+#logs-view
+{
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 12px;
+    line-height: 1.45;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: #ddd;
+    margin: 0;
+    background-color: transparent;
+}

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -13,7 +13,6 @@
         <link rel="icon" type="image/png" href="favicon.svg">
         <link rel="apple-touch-icon" href="/favicon512.png">
         <link rel="manifest" href="/manifest.json">
-        <meta name="theme-color" content="{{ theme_color }}">
         <style>
             html {
                 --theme-bg: {{ "#000" if amoled_bg else "#1a1a1a" }};
@@ -22,25 +21,162 @@
             }
         </style>
     </head>
-    <body>
-    
-        <div style="display: inline-block; text-align: center; width: 100%" class="non-video">
-            <img src="favicon.svg" alt="" height="250px">
-            <h1 style="margin-top: 0; margin-bottom: 100px; color: {{ theme_color }};">{{ app_title }}</h1>
-            <div id="main-input">
-                <input type="text" id="url" name="url" placeholder="Search / Paste URL / click enter" autofocus/>
-                <button onclick="handlePlayButtonClick()" id="submit">
-                    <i class="fa-solid fa-play"></i>
-                </button>
-            </div>
+    <body class="library-body">
+        <div class="library-page">
+            <header class="home-header">
+                <div class="home-title-row">
+                    <img src="favicon.svg" alt="" class="home-logo">
+                    <h1 style="color: {{ theme_color }};">{{ app_title }}</h1>
+                    <span class="library-count">{{ total }} video{{ '' if total == 1 else 's' }}</span>
+                    <a href="{{ '/' if show_hidden else '/?show_hidden=1' }}" class="library-rebuild" title="{{ 'Hide the hidden items again' if show_hidden else 'Show items you have hidden' }}">
+                        <i class="fa-solid {{ 'fa-eye-slash' if show_hidden else 'fa-eye' }}"></i>
+                        {{ 'Hide hidden' if show_hidden else 'Show hidden' }}
+                    </a>
+                    <button id="rebuild" class="library-rebuild" title="Rescan ./data and rebuild the library index">
+                        <i class="fa-solid fa-rotate"></i> Rebuild
+                    </button>
+                </div>
+                <div class="home-url-bar" id="main-input">
+                    <input type="text" id="url" name="url" placeholder="Filter library or paste URL" autofocus autocomplete="off"/>
+                    <button onclick="handlePlayButtonClick()" id="submit" title="Play URL">
+                        <i class="fa-solid fa-play"></i>
+                    </button>
+                </div>
+                <p id="no-matches" class="library-empty" style="display: none; margin-top: 24px;">No videos match that filter.</p>
+            </header>
+
+            {% if all_sites or all_categories or all_tags %}
+                <div class="filter-chips">
+                    <div id="active-filters" class="filter-active-row" style="display: none;">
+                        <span class="filter-label">Active</span>
+                        <div class="chips" id="active-chip-list"></div>
+                        <button id="clear-filters" class="chip-clear">Clear</button>
+                    </div>
+                    {% if all_sites %}
+                        <div class="filter-row">
+                            <span class="filter-label">Sites</span>
+                            <div class="chips">
+                                {% for s in all_sites %}
+                                    <span class="chip-wrap">
+                                        <button class="chip chip-site {{ 'chip-is-hidden' if s.hidden else '' }}" data-filter-type="site" data-filter-name="{{ s.name }}">
+                                            {{ s.name }} <span class="chip-count">{{ s.cnt }}</span>
+                                        </button>
+                                        <button class="chip-hide-toggle" data-site="{{ s.name }}" data-hidden="{{ '1' if s.hidden else '0' }}" title="{{ 'Unhide this site' if s.hidden else 'Hide this site' }}">
+                                            <i class="fa-solid {{ 'fa-eye' if s.hidden else 'fa-eye-slash' }}"></i>
+                                        </button>
+                                    </span>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    {% endif %}
+                    {% if all_categories %}
+                        <div class="filter-row">
+                            <span class="filter-label">Categories</span>
+                            <div class="chips">
+                                {% for c in all_categories %}
+                                    <button class="chip chip-cat" data-filter-type="cat" data-filter-name="{{ c.name }}">
+                                        {{ c.name }} <span class="chip-count">{{ c.cnt }}</span>
+                                    </button>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    {% endif %}
+                    {% if all_tags %}
+                        <div class="filter-row">
+                            <span class="filter-label">Tags</span>
+                            <div class="chips" id="tag-chip-list">
+                                {% for t in all_tags[:15] %}
+                                    <button class="chip chip-tag" data-filter-type="tag" data-filter-name="{{ t.name }}">
+                                        {{ t.name }} <span class="chip-count">{{ t.cnt }}</span>
+                                    </button>
+                                {% endfor %}
+                                {% if all_tags|length > 15 %}
+                                    {% for t in all_tags[15:] %}
+                                        <button class="chip chip-tag chip-tag-more" data-filter-type="tag" data-filter-name="{{ t.name }}" style="display: none;">
+                                            {{ t.name }} <span class="chip-count">{{ t.cnt }}</span>
+                                        </button>
+                                    {% endfor %}
+                                    <button class="chip chip-more-toggle" id="show-more-tags">
+                                        + {{ all_tags|length - 15 }} more
+                                    </button>
+                                {% endif %}
+                            </div>
+                        </div>
+                    {% endif %}
+                </div>
+            {% endif %}
+
+            {% if total == 0 %}
+                <p class="library-empty">
+                    No videos in the library yet. Paste a URL above to play &amp; save one.<br>
+                    Already have downloads on disk? Click <strong>Rebuild</strong> to index them.
+                </p>
+            {% else %}
+                {% for site, site_entries in grouped.items() %}
+                    <section class="library-section">
+                        <h2 class="library-section-title">
+                            {{ site }}
+                            <span class="library-section-count">{{ site_entries|length }}</span>
+                        </h2>
+                        <div class="library-grid">
+                            {% for e in site_entries %}
+                                <div class="library-card {{ 'is-hidden-card' if e.hidden or e.site_hidden else '' }}" data-url="{{ e.url }}"
+                                     data-site="{{ (e.source_site or '')|lower }}"
+                                     data-cats="{{ (e.categories|join('|'))|lower }}"
+                                     data-tags="{{ (e.tags|join('|'))|lower }}"
+                                     data-hidden="{{ '1' if e.hidden else '0' }}">
+                                    <a class="library-thumb-link" href="/watch?url={{ e.url|urlencode }}">
+                                        <div class="library-thumb-wrap">
+                                            {% if e.has_thumb %}
+                                                <img loading="lazy" src="/thumb?url={{ e.url|urlencode }}" alt="">
+                                            {% else %}
+                                                <div class="library-thumb-fallback"><i class="fa-solid fa-film"></i></div>
+                                            {% endif %}
+                                            {% if e.duration %}
+                                                <span class="library-duration">
+                                                    {%- set h = (e.duration // 3600) -%}
+                                                    {%- set m = ((e.duration % 3600) // 60) -%}
+                                                    {%- set s = (e.duration % 60) -%}
+                                                    {%- if h -%}{{ h }}:{{ '%02d' % m }}:{{ '%02d' % s }}{%- else -%}{{ m }}:{{ '%02d' % s }}{%- endif -%}
+                                                </span>
+                                            {% endif %}
+                                        </div>
+                                    </a>
+                                    <div class="library-meta">
+                                        <a class="library-title" href="/watch?url={{ e.url|urlencode }}" title="{{ e.title }}">{{ e.title }}</a>
+                                        {% if e.uploader %}<div class="library-uploader">{{ e.uploader }}</div>{% endif %}
+                                        {% if e.categories or e.tags %}
+                                            <div class="card-chips">
+                                                {% for c in e.categories %}
+                                                    <button class="chip chip-cat chip-sm" data-filter-type="cat" data-filter-name="{{ c }}">{{ c }}</button>
+                                                {% endfor %}
+                                                {% for t in e.tags[:3] %}
+                                                    <button class="chip chip-tag chip-sm" data-filter-type="tag" data-filter-name="{{ t }}">{{ t }}</button>
+                                                {% endfor %}
+                                                {% if e.tags|length > 3 %}
+                                                    <span class="chip-more" title="{{ e.tags[3:]|join(', ') }}">+{{ e.tags|length - 3 }}</span>
+                                                {% endif %}
+                                            </div>
+                                        {% endif %}
+                                    </div>
+                                    <button class="library-hide" title="{{ 'Unhide' if e.hidden else 'Hide' }}" aria-label="{{ 'Unhide' if e.hidden else 'Hide' }}">
+                                        <i class="fa-solid {{ 'fa-eye' if e.hidden else 'fa-eye-slash' }}"></i>
+                                    </button>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </section>
+                {% endfor %}
+            {% endif %}
         </div>
-        
+
         <div id="expandable-menu-container">
             <button id="expand-button" class="expand-button" aria-label="Menu">
                 <i class="fa-solid fa-chevron-up"></i>
             </button>
             <div id="expandable-content" class="expandable-content">
                 <ul>
+                    <li><a href="/logs"><i class="fa-solid fa-terminal"></i> Logs</a></li>
                     <li><a href="javascript:void(0)" onclick="copyExtensionScript(event)" id="script-copy"><i class="fa-solid fa-file-code"></i> Copy extension JS</a></li>
                     <li>
                         <a href="https://github.com/Matszwe02/ytdlp_web_player" target="_blank">
@@ -53,6 +189,7 @@
                 </ul>
             </div>
         </div>
+
         <script>
             const expandButton = document.getElementById('expand-button');
             const expandableContent = document.getElementById('expandable-content');
@@ -60,13 +197,10 @@
             expandButton.addEventListener('click', function(event) {
                 event.stopPropagation();
                 isExpanded = !isExpanded;
-                if (isExpanded)
-                {
+                if (isExpanded) {
                     expandableContent.style.maxHeight = expandableContent.scrollHeight + "px";
                     expandButton.classList.add('expanded');
-                }
-                else
-                {
+                } else {
                     expandableContent.style.maxHeight = "0";
                     expandButton.classList.remove('expanded');
                 }
@@ -74,8 +208,7 @@
 
             document.addEventListener('click', function(event) {
                 const expandableMenuContainer = document.getElementById('expandable-menu-container');
-                if (isExpanded && !expandableMenuContainer.contains(event.target))
-                {
+                if (isExpanded && !expandableMenuContainer.contains(event.target)) {
                     expandButton.click();
                 }
             });
@@ -88,40 +221,139 @@
                 }
             });
 
-            function handlePlayButtonClick()
-            {
-                let url = urlInput.value.trim();
-                if (url)
-                {
-                    try
-                    {
-                        const expression = /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/gi;
-                        if (!url.match(new RegExp(expression))) throw TypeError();
-                        if (!url.startsWith('http')) url = 'https://' + url;
-                        new URL(url);
-                        window.location.href = '/watch?url=' + encodeURIComponent(url);
-                    }
-                    catch (e)
-                    {
-                        fetch(`/search?q=${encodeURIComponent(url)}`)
-                            .then(response => {
-                                if (!response.ok) return;
-                                response.text().then(data => {
-                                    if (!data) return;
-                                    window.location.href = '/watch?url=' + encodeURIComponent(data);
-                                });
-                            })
-                    }
+            const urlRegex = /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/gi;
+
+            function tryPlayUrl(text) {
+                let url = (text || '').trim();
+                if (!url) return false;
+                try {
+                    if (!url.match(new RegExp(urlRegex))) return false;
+                    if (!url.startsWith('http')) url = 'https://' + url;
+                    new URL(url);
+                    window.location.href = '/watch?url=' + encodeURIComponent(url);
+                    return true;
+                } catch (e) {
+                    return false;
+                }
+            }
+
+            function handlePlayButtonClick() {
+                const text = urlInput.value.trim();
+                if (text) {
+                    tryPlayUrl(text);
                     return;
                 }
-                navigator.clipboard.readText()
-                    .then(clipboardText => {
-                        url = clipboardText.trim();
-                        window.location.href = '/watch?url=' + encodeURIComponent(url);
-                    })
+                navigator.clipboard.readText().then(clipboardText => {
+                    tryPlayUrl(clipboardText);
+                });
             }
-            function copyExtensionScript(event)
-            {
+
+            const noMatchesEl = document.getElementById('no-matches');
+            const cards = Array.from(document.querySelectorAll('.library-card'));
+            const sections = Array.from(document.querySelectorAll('.library-section'));
+            const activeFiltersEl = document.getElementById('active-filters');
+            const activeChipList = document.getElementById('active-chip-list');
+            const clearFiltersBtn = document.getElementById('clear-filters');
+            const showMoreTagsBtn = document.getElementById('show-more-tags');
+
+            const activeFilters = { site: new Set(), cat: new Set(), tag: new Set() };
+            const FILTER_ATTR = { site: 'data-site', cat: 'data-cats', tag: 'data-tags' };
+
+            function cardHasAll(card, type, needed) {
+                if (needed.size === 0) return true;
+                const raw = (card.getAttribute(FILTER_ATTR[type]) || '');
+                if (!raw) return false;
+                const set = new Set(raw.split('|').filter(Boolean));
+                for (const n of needed) if (!set.has(n)) return false;
+                return true;
+            }
+
+            function refreshChipStates() {
+                document.querySelectorAll('.chip[data-filter-type]').forEach(chip => {
+                    const type = chip.getAttribute('data-filter-type');
+                    const name = chip.getAttribute('data-filter-name').toLowerCase();
+                    chip.classList.toggle('active', activeFilters[type].has(name));
+                });
+                renderActiveFilters();
+            }
+
+            function renderActiveFilters() {
+                if (!activeFiltersEl || !activeChipList) return;
+                const total = activeFilters.cat.size + activeFilters.tag.size;
+                if (total === 0) {
+                    activeFiltersEl.style.display = 'none';
+                    return;
+                }
+                activeFiltersEl.style.display = '';
+                activeChipList.innerHTML = '';
+                for (const [type, set] of [['site', activeFilters.site], ['cat', activeFilters.cat], ['tag', activeFilters.tag]]) {
+                    for (const name of set) {
+                        const b = document.createElement('button');
+                        b.className = 'chip chip-active chip-' + type;
+                        b.dataset.filterType = type;
+                        b.dataset.filterName = name;
+                        b.innerHTML = name + ' <i class="fa-solid fa-xmark"></i>';
+                        b.addEventListener('click', () => toggleFilter(type, name));
+                        activeChipList.appendChild(b);
+                    }
+                }
+            }
+
+            function applyFilter() {
+                const q = urlInput.value.trim().toLowerCase();
+                let anyVisible = false;
+                cards.forEach(card => {
+                    let match = true;
+                    if (q) {
+                        const title = (card.querySelector('.library-title')?.textContent || '').toLowerCase();
+                        const uploader = (card.querySelector('.library-uploader')?.textContent || '').toLowerCase();
+                        const url = (card.getAttribute('data-url') || '').toLowerCase();
+                        if (!(title.includes(q) || uploader.includes(q) || url.includes(q))) match = false;
+                    }
+                    if (match && !cardHasAll(card, 'site', activeFilters.site)) match = false;
+                    if (match && !cardHasAll(card, 'cat', activeFilters.cat)) match = false;
+                    if (match && !cardHasAll(card, 'tag', activeFilters.tag)) match = false;
+                    card.style.display = match ? '' : 'none';
+                    if (match) anyVisible = true;
+                });
+                sections.forEach(section => {
+                    const visible = section.querySelectorAll('.library-card:not([style*="display: none"])').length;
+                    section.style.display = visible ? '' : 'none';
+                });
+                const anyFilter = q || activeFilters.site.size || activeFilters.cat.size || activeFilters.tag.size;
+                if (noMatchesEl) noMatchesEl.style.display = (anyFilter && !anyVisible) ? '' : 'none';
+            }
+
+            function toggleFilter(type, name) {
+                name = name.toLowerCase();
+                const set = activeFilters[type];
+                if (set.has(name)) set.delete(name); else set.add(name);
+                refreshChipStates();
+                applyFilter();
+            }
+
+            document.addEventListener('click', (ev) => {
+                const chip = ev.target.closest('.chip[data-filter-type]');
+                if (!chip || chip.classList.contains('chip-active')) return;
+                toggleFilter(chip.getAttribute('data-filter-type'), chip.getAttribute('data-filter-name'));
+            });
+
+            if (clearFiltersBtn) clearFiltersBtn.addEventListener('click', () => {
+                activeFilters.site.clear();
+                activeFilters.cat.clear();
+                activeFilters.tag.clear();
+                refreshChipStates();
+                applyFilter();
+            });
+
+            if (showMoreTagsBtn) showMoreTagsBtn.addEventListener('click', () => {
+                document.querySelectorAll('.chip-tag-more').forEach(c => c.style.display = '');
+                showMoreTagsBtn.remove();
+            });
+
+            urlInput.addEventListener('input', applyFilter);
+
+            function copyExtensionScript(event) {
                 fetch('https://raw.githubusercontent.com/Matszwe02/ytdlp_web_player/refs/heads/main/extension/extension.js')
                     .then(response => {
                         if (!response.ok) return;
@@ -136,6 +368,77 @@
                         });
                     })
             }
+
+            const rebuildBtn = document.getElementById('rebuild');
+            rebuildBtn.addEventListener('click', async () => {
+                const originalHTML = rebuildBtn.innerHTML;
+                rebuildBtn.disabled = true;
+                rebuildBtn.innerHTML = '<i class="fa-solid fa-rotate fa-spin"></i> Rebuilding';
+                try {
+                    const resp = await fetch('/library/rebuild', { method: 'POST' });
+                    if (!resp.ok) throw new Error(await resp.text());
+                    const data = await resp.json();
+                    rebuildBtn.innerHTML = '<i class="fa-solid fa-check"></i> ' + data.count + ' indexed';
+                    setTimeout(() => window.location.reload(), 700);
+                } catch (e) {
+                    alert('Rebuild failed: ' + e.message);
+                    rebuildBtn.innerHTML = originalHTML;
+                    rebuildBtn.disabled = false;
+                }
+            });
+
+            document.querySelectorAll('.library-hide').forEach(btn => {
+                btn.addEventListener('click', async (ev) => {
+                    ev.preventDefault();
+                    ev.stopPropagation();
+                    const card = btn.closest('.library-card');
+                    const url = card.getAttribute('data-url');
+                    const currentlyHidden = card.getAttribute('data-hidden') === '1';
+                    const endpoint = currentlyHidden ? '/library/unhide' : '/library/hide';
+                    btn.disabled = true;
+                    try {
+                        const resp = await fetch(endpoint + '?url=' + encodeURIComponent(url), { method: 'POST' });
+                        if (!resp.ok) throw new Error(await resp.text());
+                        // If we're in default view and just hid: remove from DOM
+                        // If in show-hidden view: flip icon + data attribute
+                        const showHidden = new URLSearchParams(window.location.search).get('show_hidden');
+                        if (!showHidden && !currentlyHidden) {
+                            card.remove();
+                            applyFilter();
+                        } else {
+                            const nowHidden = !currentlyHidden;
+                            card.setAttribute('data-hidden', nowHidden ? '1' : '0');
+                            card.classList.toggle('is-hidden-card', nowHidden || (card.getAttribute('data-site-hidden') === '1'));
+                            btn.innerHTML = '<i class="fa-solid ' + (nowHidden ? 'fa-eye' : 'fa-eye-slash') + '"></i>';
+                            btn.title = nowHidden ? 'Unhide' : 'Hide';
+                        }
+                    } catch (e) {
+                        alert('Failed: ' + e.message);
+                    } finally {
+                        btn.disabled = false;
+                    }
+                });
+            });
+
+            document.querySelectorAll('.chip-hide-toggle').forEach(btn => {
+                btn.addEventListener('click', async (ev) => {
+                    ev.preventDefault();
+                    ev.stopPropagation();
+                    const site = btn.getAttribute('data-site');
+                    const currentlyHidden = btn.getAttribute('data-hidden') === '1';
+                    const endpoint = currentlyHidden ? '/library/site/unhide' : '/library/site/hide';
+                    btn.disabled = true;
+                    try {
+                        const resp = await fetch(endpoint + '?name=' + encodeURIComponent(site), { method: 'POST' });
+                        if (!resp.ok) throw new Error(await resp.text());
+                        window.location.reload();
+                    } catch (e) {
+                        alert('Failed: ' + e.message);
+                        btn.disabled = false;
+                    }
+                });
+            });
+
             if (typeof navigator.serviceWorker !== 'undefined')
                 navigator.serviceWorker.register("/sw.js", { scope: '/' })
         </script>

--- a/src/templates/logs.html
+++ b/src/templates/logs.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, viewport-fit=cover, initial-scale=1.0" />
+        <meta name="theme-color" content="{{ theme_color }}">
+        <meta name="color-scheme" content="dark">
+        <title>Logs - {{ app_title }}</title>
+        <link rel="stylesheet" href="{{ url_for('static', filename='fontawesome/css/all.min.css') }}" />
+        <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+        <link rel="icon" type="image/png" href="/favicon.svg">
+        <style>
+            html {
+                --theme-bg: #0e0e0e;
+                --theme-bg-light: #191919;
+                --theme-fg: #888;
+            }
+        </style>
+    </head>
+    <body class="logs-body">
+        <div class="logs-page">
+            <div class="logs-toolbar">
+                <a href="/" class="library-home" title="Home"><i class="fa-solid fa-house"></i></a>
+                <h1 style="color: {{ theme_color }};">Logs</h1>
+                <label><input type="checkbox" id="follow" checked> Follow</label>
+                <label><input type="checkbox" id="wrap" checked> Wrap</label>
+                <button id="clear-btn" title="Truncate the log file"><i class="fa-solid fa-eraser"></i> Clear</button>
+                <button id="pause-btn" title="Pause polling"><i class="fa-solid fa-pause"></i> Pause</button>
+                <span class="logs-status" id="status">{{ log_path or 'log capture not initialized' }}</span>
+            </div>
+            <pre id="logs-view"></pre>
+        </div>
+
+        <script>
+            const view = document.getElementById('logs-view');
+            const status = document.getElementById('status');
+            const follow = document.getElementById('follow');
+            const wrap = document.getElementById('wrap');
+            const clearBtn = document.getElementById('clear-btn');
+            const pauseBtn = document.getElementById('pause-btn');
+
+            let sinceBytes = null;
+            let paused = false;
+
+            function updateWrap() {
+                view.style.whiteSpace = wrap.checked ? 'pre-wrap' : 'pre';
+            }
+            wrap.addEventListener('change', updateWrap);
+            updateWrap();
+
+            async function poll() {
+                if (paused) return;
+                try {
+                    const url = sinceBytes === null ? '/logs/tail' : ('/logs/tail?since=' + sinceBytes);
+                    const resp = await fetch(url);
+                    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+                    const size = parseInt(resp.headers.get('X-Log-Size') || '0', 10);
+                    const text = await resp.text();
+                    if (sinceBytes === null) {
+                        view.textContent = text;
+                    } else if (text) {
+                        view.textContent += text;
+                    }
+                    sinceBytes = size;
+                    status.textContent = size.toLocaleString() + ' bytes';
+                    if (follow.checked) window.scrollTo(0, document.body.scrollHeight);
+                } catch (e) {
+                    status.textContent = 'error: ' + e.message;
+                }
+            }
+
+            clearBtn.addEventListener('click', async () => {
+                if (!confirm('Truncate the log file?')) return;
+                try {
+                    const resp = await fetch('/logs/clear', { method: 'POST' });
+                    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+                    sinceBytes = null;
+                    view.textContent = '';
+                    poll();
+                } catch (e) {
+                    alert('Clear failed: ' + e.message);
+                }
+            });
+
+            pauseBtn.addEventListener('click', () => {
+                paused = !paused;
+                pauseBtn.innerHTML = paused
+                    ? '<i class="fa-solid fa-play"></i> Resume'
+                    : '<i class="fa-solid fa-pause"></i> Pause';
+            });
+
+            poll();
+            setInterval(poll, 1500);
+        </script>
+    </body>
+</html>

--- a/src/templates/watch.html
+++ b/src/templates/watch.html
@@ -62,6 +62,42 @@
             </video>
         </div>
         
+        {% if debug %}
+        <details class="watch-debug">
+            <summary><i class="fa-solid fa-bug"></i> Debug info</summary>
+            <div class="watch-debug-body">
+                <table>
+                    <tr><th>URL</th><td><a href="{{ debug.url }}" target="_blank">{{ debug.url }}</a></td></tr>
+                    <tr><th>Hash</th><td><code>{{ debug.dir_hash }}</code></td></tr>
+                    <tr><th>Data dir</th><td><code>{{ debug.data_dir }}</code></td></tr>
+                </table>
+
+                <h4>Meta highlights</h4>
+                {% if debug.meta_highlights %}
+                    <table>
+                        {% for k, v in debug.meta_highlights.items() %}
+                            <tr><th>{{ k }}</th><td><code>{{ v }}</code></td></tr>
+                        {% endfor %}
+                    </table>
+                    <p><a href="/debug/meta?url={{ debug.url|urlencode }}" target="_blank"><i class="fa-solid fa-arrow-up-right-from-square"></i> View raw meta.json</a></p>
+                {% else %}
+                    <p><em>meta not yet available</em></p>
+                {% endif %}
+
+                <h4>Files on disk ({{ debug.files|length }})</h4>
+                {% if debug.files %}
+                    <table>
+                        {% for f in debug.files %}
+                            <tr><th>{{ f.name }}</th><td>{{ f.size }}</td></tr>
+                        {% endfor %}
+                    </table>
+                {% else %}
+                    <p><em>no files yet</em></p>
+                {% endif %}
+            </div>
+        </details>
+        {% endif %}
+
         <div id="expandable-menu-container">
             <button id="expand-button" class="expand-button" aria-label="Menu">
                 <i class="fa-solid fa-chevron-up"></i>


### PR DESCRIPTION
## Summary

- Home page becomes a **persistent library** grouped by source site, with filter chips for **sites**, **categories**, and **tags** that combine (AND) with a live text search
- **Hide** replaces delete (per-video and per-site), with a **Show hidden** toggle to bring things back
- SQLite index at `data/library.db` with auto-sync on download/watch; **Rebuild** button for manual resync
- **ffprobe-backfill** fills missing `meta.duration` from downloaded media; `SAVE_ALL=true` (default) keeps videos permanently instead of expiring after `MAX_VIDEO_AGE`
- **`/logs`** page for live stdout/stderr tailing and a **Debug info** panel on `/watch` (dir hash, meta highlights, files on disk, raw meta.json link)
- Fix HLS proxy in `stream_media_file`: detect `.m3u8` by URL suffix when CDNs mislabel `Content-Type`, and always return `application/vnd.apple.mpegurl` after rewriting inner URIs
- Relocate `.env` and `cookies.txt` into the mounted `data/` folder so they survive container rebuilds and don't require compose edits

