### PR TITLE
Improve video caching and downloading

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,9 +8,3 @@
 **/__pycache__/
 **/.ssl/
 **/cookies.txt
-
-# Ignore a virtual environment created directly inside src
-src/bin/
-src/lib/
-src/share/
-src/pyvenv.cfg

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,9 @@
 **/__pycache__/
 **/.ssl/
 **/cookies.txt
+
+# Ignore a virtual environment created directly inside src
+src/bin/
+src/lib/
+src/share/
+src/pyvenv.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ app/*.png
 dist
 build
 *.spec
+.idea
+**/.DS_Store

--- a/src/addons.py
+++ b/src/addons.py
@@ -25,6 +25,80 @@ from sb import SponsorBlock
 yt_dlp = External.yt_dlp()
 
 
+class CacheLockStore:
+    """Filesystem store for cache-job and media-generation locks."""
+
+    def __init__(self, url, media_type):
+        self.data_dir = get_data_dir(url)
+        self.media_lock_path = os.path.join(self.data_dir, f'{media_type}.temp')
+        self.job_lock_path = os.path.join(self.data_dir, f'{media_type}.cache-start.temp')
+
+    @staticmethod
+    def _exists(path):
+        return os.path.exists(path)
+
+    @staticmethod
+    def _try_acquire(path, cleanup_on_error=False):
+        try:
+            descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+        except FileExistsError:
+            return False
+
+        try:
+            with os.fdopen(descriptor, 'w') as lock_file:
+                lock_file.write(datetime.now().isoformat())
+        except Exception:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+            if cleanup_on_error:
+                CacheLockStore._release(path)
+            raise
+        return True
+
+    @staticmethod
+    def _release(path):
+        try:
+            os.remove(path)
+            return True
+        except FileNotFoundError:
+            return False
+
+    def media_lock_exists(self):
+        return self._exists(self.media_lock_path)
+
+    def job_lock_exists(self):
+        return self._exists(self.job_lock_path)
+
+    def any_lock_exists(self):
+        return self.media_lock_exists() or self.job_lock_exists()
+
+    def try_acquire_media_lock(self):
+        os.makedirs(self.data_dir, exist_ok=True)
+        return self._try_acquire(self.media_lock_path, cleanup_on_error=True)
+
+    def try_acquire_job_lock(self):
+        os.makedirs(self.data_dir, exist_ok=True)
+        return self._try_acquire(self.job_lock_path)
+
+    def release_media_lock(self):
+        return self._release(self.media_lock_path)
+
+    def release_job_lock(self):
+        return self._release(self.job_lock_path)
+
+    def remove_stale_job_lock(self, max_age):
+        if not self.job_lock_exists() or self.media_lock_exists():
+            return False
+        try:
+            if time.time() - os.path.getmtime(self.job_lock_path) <= max_age:
+                return False
+        except FileNotFoundError:
+            return False
+        return self.release_job_lock()
+
+
 class FileCachingLock:
     max_wait_attempts = 600
     retry_interval_seconds = 1
@@ -32,16 +106,14 @@ class FileCachingLock:
     def __init__(self, url, media_type):
         self.url = url
         self.media_type = media_type
-        self.data_dir = get_data_dir(url)
-        self.lock_path = os.path.join(self.data_dir, f'{self.media_type}.temp')
+        self.store = CacheLockStore(url, media_type)
+        self.data_dir = self.store.data_dir
+        self.lock_path = self.store.media_lock_path
         self.acquired = False
 
     def __enter__(self):
-        os.makedirs(self.data_dir, exist_ok=True)
         for attempt in range(self.max_wait_attempts):
-            try:
-                descriptor = os.open(self.lock_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
-            except FileExistsError:
+            if not self.store.try_acquire_media_lock():
                 if attempt == self.max_wait_attempts - 1:
                     raise TimeoutError(
                         f'Timed out waiting for download of {self.media_type} '
@@ -53,8 +125,6 @@ class FileCachingLock:
 
             self.acquired = True
             try:
-                with os.fdopen(descriptor, 'w') as lock_file:
-                    lock_file.write(datetime.now().isoformat())
                 keepalive(self.data_dir)
                 if cached_media := check_media(url=self.url, media_type=self.media_type):
                     if is_compatible_cached_media(cached_media, self.media_type):
@@ -67,10 +137,6 @@ class FileCachingLock:
                         pass
                 return None
             except Exception:
-                try:
-                    os.close(descriptor)
-                except OSError:
-                    pass
                 self._release()
                 raise
 
@@ -78,9 +144,8 @@ class FileCachingLock:
         if not self.acquired:
             return
         try:
-            os.remove(self.lock_path)
-        except FileNotFoundError:
-            print(f'FATAL ERROR trying to unlock {self.media_type} of {self.data_dir}. Media type cannot be downloaded')
+            if not self.store.release_media_lock():
+                print(f'FATAL ERROR trying to unlock {self.media_type} of {self.data_dir}. Media type cannot be downloaded')
         finally:
             self.acquired = False
 
@@ -150,8 +215,49 @@ class Processes:
 
 
 
+class CacheProgressStore:
+    """Filesystem store for cache-job progress records."""
+
+    def __init__(self, url, progress_id):
+        self.progress_id = progress_id if self.valid_id(progress_id) else None
+        self.path = self.get_path(url, self.progress_id) if self.progress_id else None
+
+    @staticmethod
+    def valid_id(progress_id):
+        return isinstance(progress_id, str) and re.fullmatch(r'[A-Za-z0-9_-]{1,80}', progress_id) is not None
+
+    @staticmethod
+    def get_path(url, progress_id):
+        return os.path.join(get_data_dir(url), f'download-progress-{progress_id}.json')
+
+    def read(self):
+        if not self.path:
+            return None
+        try:
+            with open(self.path, 'r') as progress_file:
+                return json.load(progress_file)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return None
+
+    def write(self, state):
+        if not self.path:
+            return
+
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        temp_path = f'{self.path}.{os.getpid()}.{time.time_ns()}.temp'
+        try:
+            with open(temp_path, 'w') as progress_file:
+                json.dump(state, progress_file)
+            os.replace(temp_path, self.path)
+        finally:
+            try:
+                os.remove(temp_path)
+            except FileNotFoundError:
+                pass
+
+
 class DownloadProgress:
-    """Persists download progress so it can be read by any web worker."""
+    """Tracks cache-job progress and delegates its persistence to the store."""
 
     update_interval = 0.2
     ffmpeg_postprocessors = {
@@ -163,8 +269,9 @@ class DownloadProgress:
 
     def __init__(self, url: str, progress_id: str | None):
         self.url = url
-        self.progress_id = progress_id if self.valid_id(progress_id) else None
-        self.path = self.get_path(url, self.progress_id) if self.progress_id else None
+        self.store = CacheProgressStore(url, progress_id)
+        self.progress_id = self.store.progress_id
+        self.path = self.store.path
         self.last_write = 0
         self.state = self.initial_state()
 
@@ -180,42 +287,30 @@ class DownloadProgress:
 
     @staticmethod
     def valid_id(progress_id):
-        return isinstance(progress_id, str) and re.fullmatch(r'[A-Za-z0-9_-]{1,80}', progress_id) is not None
+        return CacheProgressStore.valid_id(progress_id)
 
     @staticmethod
     def get_path(url, progress_id):
-        return os.path.join(get_data_dir(url), f'download-progress-{progress_id}.json')
+        return CacheProgressStore.get_path(url, progress_id)
 
     @classmethod
     def read(cls, url, progress_id):
-        if not cls.valid_id(progress_id): return None
-        try:
-            with open(cls.get_path(url, progress_id), 'r') as f:
-                return json.load(f)
-        except (FileNotFoundError, json.JSONDecodeError):
-            return None
+        return CacheProgressStore(url, progress_id).read()
 
     def _write(self, force=False):
-        if not self.path: return
+        if not self.progress_id: return
         now = time.time()
         if not force and now - self.last_write < self.update_interval: return
 
         self.last_write = now
         self.state['timestamp'] = now
-        os.makedirs(os.path.dirname(self.path), exist_ok=True)
-        temp_path = f'{self.path}.{os.getpid()}.{time.time_ns()}.temp'
-        try:
-            with open(temp_path, 'w') as f:
-                json.dump(self.state, f)
-            os.replace(temp_path, self.path)
-        finally:
-            if os.path.exists(temp_path): os.remove(temp_path)
+        self.store.write(self.state)
 
     def start(self):
         self._write(force=True)
 
     @staticmethod
-    def _number(value, default=0):
+    def number(value, default=0):
         try:
             value = float(value)
             return value if math.isfinite(value) and value >= 0 else default
@@ -224,19 +319,19 @@ class DownloadProgress:
 
     def download(self, data):
         previous_status = self.state.get('status')
-        downloaded = self._number(data.get('downloaded_bytes'))
-        total = self._number(
+        downloaded = self.number(data.get('downloaded_bytes'))
+        total = self.number(
             data.get('total_bytes')
             or data.get('total_bytes_estimate')
             or data.get('filesize')
             or data.get('filesize_approx')
         )
-        speed = self._number(data.get('speed'), self.state.get('speed', 0))
+        speed = self.number(data.get('speed'), self.state.get('speed', 0))
         status = data.get('status')
 
         if not total:
-            fragment_index = self._number(data.get('fragment_index'))
-            fragment_count = self._number(data.get('fragment_count'))
+            fragment_index = self.number(data.get('fragment_index'))
+            fragment_count = self.number(data.get('fragment_count'))
             if fragment_index and fragment_count:
                 total = downloaded * fragment_count / fragment_index
 
@@ -276,7 +371,7 @@ class DownloadProgress:
         self._write(force=True)
 
     def ready(self, file_size):
-        file_size = self._number(file_size)
+        file_size = self.number(file_size)
         self.state.update({
             'status': 'ready',
             'percent': 100,
@@ -1199,8 +1294,7 @@ def get_ready_cached_video(url: str, quality: str, validate=True):
         return None
 
     media_type = f'video-{quality}'
-    data_dir = get_data_dir(url)
-    if os.path.exists(os.path.join(data_dir, f'{media_type}.temp')):
+    if CacheLockStore(url, media_type).media_lock_exists():
         return None
 
     path = check_media(url, media_type)
@@ -1249,7 +1343,7 @@ def read_video_cache_progress(url, quality):
         return None
 
     progress = DownloadProgress(url, progress_id)
-    video_state = DownloadProgress.read(url, progress_id) or DownloadProgress.initial_state()
+    video_state = CacheProgressStore(url, progress_id).read() or DownloadProgress.initial_state()
     ready_video = get_ready_cached_video(url, quality)
     if ready_video:
         file_size = os.path.getsize(ready_video)
@@ -1267,7 +1361,7 @@ def read_video_cache_progress(url, quality):
         return video_state
 
     audio_progress = DownloadProgress(url, CACHE_AUDIO_PROGRESS_ID)
-    audio_state = DownloadProgress.read(url, CACHE_AUDIO_PROGRESS_ID) or DownloadProgress.initial_state()
+    audio_state = CacheProgressStore(url, CACHE_AUDIO_PROGRESS_ID).read() or DownloadProgress.initial_state()
     audio_file = _find_cached_media(url, 'audio')
     if audio_file:
         audio_size = os.path.getsize(audio_file)
@@ -1279,15 +1373,15 @@ def read_video_cache_progress(url, quality):
         audio_state = audio_progress.state
 
     downloaded = sum(
-        DownloadProgress._number(state.get('downloaded_bytes'))
+        DownloadProgress.number(state.get('downloaded_bytes'))
         for state in (video_state, audio_state)
     )
     total = sum(
-        DownloadProgress._number(state.get('total_bytes'))
+        DownloadProgress.number(state.get('total_bytes'))
         for state in (video_state, audio_state)
     )
     speed = sum(
-        DownloadProgress._number(state.get('speed'))
+        DownloadProgress.number(state.get('speed'))
         for state in (video_state, audio_state)
         if state.get('status') == 'downloading'
     )
@@ -1308,14 +1402,15 @@ def read_video_cache_progress(url, quality):
         'total_bytes': total,
         'speed': speed,
         'timestamp': max(
-            DownloadProgress._number(video_state.get('timestamp')),
-            DownloadProgress._number(audio_state.get('timestamp')),
+            DownloadProgress.number(video_state.get('timestamp')),
+            DownloadProgress.number(audio_state.get('timestamp')),
         ),
     }
 
 
-def _cache_video_worker(url, quality, start_marker):
+def _cache_video_worker(url, quality):
     progress = DownloadProgress(url, cache_progress_id(quality))
+    lock_store = CacheLockStore(url, f'video-{quality}')
     try:
         media_type = f'video-{quality}'
         cached_video = MediaDownloader(url, media_type, progress).run()
@@ -1327,10 +1422,7 @@ def _cache_video_worker(url, quality, start_marker):
         pprint_exc(error)
         progress.error(error)
     finally:
-        try:
-            os.remove(start_marker)
-        except FileNotFoundError:
-            pass
+        lock_store.release_job_lock()
 
 
 def ensure_video_cache(url, quality):
@@ -1344,33 +1436,19 @@ def ensure_video_cache(url, quality):
         progress.ready(os.path.getsize(ready_video))
         return progress.state
 
-    data_dir = get_data_dir(url)
-    os.makedirs(data_dir, exist_ok=True)
     media_type = f'video-{quality}'
-    media_lock = os.path.join(data_dir, f'{media_type}.temp')
-    start_marker = os.path.join(data_dir, f'{media_type}.cache-start.temp')
+    lock_store = CacheLockStore(url, media_type)
+    lock_store.remove_stale_job_lock(CACHE_START_MARKER_MAX_AGE)
 
-    if os.path.exists(start_marker) and not os.path.exists(media_lock):
-        try:
-            if time.time() - os.path.getmtime(start_marker) > CACHE_START_MARKER_MAX_AGE:
-                os.remove(start_marker)
-        except FileNotFoundError:
-            pass
-
-    if os.path.exists(media_lock) or os.path.exists(start_marker):
+    if lock_store.any_lock_exists():
         return read_video_cache_progress(url, quality)
 
-    try:
-        descriptor = os.open(start_marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
-    except FileExistsError:
+    if not lock_store.try_acquire_job_lock():
         return read_video_cache_progress(url, quality)
-
-    with os.fdopen(descriptor, 'w') as marker_file:
-        marker_file.write(datetime.now().isoformat())
 
     progress = DownloadProgress(url, cache_progress_id(quality))
     progress.start()
-    Thread(target=_cache_video_worker, args=(url, quality, start_marker), daemon=True).start()
+    Thread(target=_cache_video_worker, args=(url, quality), daemon=True).start()
     return progress.state
 
 
@@ -1381,14 +1459,11 @@ def start_video_cache_if_new(url, quality):
         return None
 
     progress_id = cache_progress_id(quality)
-    if DownloadProgress.read(url, progress_id) is not None:
+    if CacheProgressStore(url, progress_id).read() is not None:
         return read_video_cache_progress(url, quality)
 
-    data_dir = get_data_dir(url)
     media_type = f'video-{quality}'
-    media_lock = os.path.join(data_dir, f'{media_type}.temp')
-    start_marker = os.path.join(data_dir, f'{media_type}.cache-start.temp')
-    if os.path.exists(media_lock) or os.path.exists(start_marker):
+    if CacheLockStore(url, media_type).any_lock_exists():
         return read_video_cache_progress(url, quality)
 
     if get_ready_cached_video(url, quality):

--- a/src/addons.py
+++ b/src/addons.py
@@ -1228,8 +1228,6 @@ def get_ready_cached_video(url: str, quality: str, validate=True):
 CACHE_PROGRESS_PREFIX = 'cache-'
 CACHE_AUDIO_PROGRESS_ID = f'{CACHE_PROGRESS_PREFIX}audio'
 CACHE_START_MARKER_MAX_AGE = 30
-CACHE_WAIT_MAX_ATTEMPTS = 600
-CACHE_WAIT_INTERVAL_SECONDS = 1
 
 
 def normalize_cache_quality(quality):
@@ -1374,40 +1372,6 @@ def ensure_video_cache(url, quality):
     progress.start()
     Thread(target=_cache_video_worker, args=(url, quality, start_marker), daemon=True).start()
     return progress.state
-
-
-def wait_for_video_cache(
-    url,
-    quality,
-    max_attempts=CACHE_WAIT_MAX_ATTEMPTS,
-    retry_interval=CACHE_WAIT_INTERVAL_SECONDS,
-):
-    """Wait for the canonical cache job instead of starting a second downloader."""
-    quality = normalize_cache_quality(quality)
-    if not url or not quality:
-        return None
-
-    ensure_video_cache(url, quality)
-    data_dir = get_data_dir(url)
-    media_type = f'video-{quality}'
-    media_lock = os.path.join(data_dir, f'{media_type}.temp')
-    start_marker = os.path.join(data_dir, f'{media_type}.cache-start.temp')
-
-    for attempt in range(max_attempts):
-        if ready_video := get_ready_cached_video(url, quality):
-            progress = DownloadProgress(url, cache_progress_id(quality))
-            progress.ready(os.path.getsize(ready_video))
-            return ready_video
-
-        state = read_video_cache_progress(url, quality) or DownloadProgress.initial_state()
-        job_active = os.path.exists(media_lock) or os.path.exists(start_marker)
-        if state.get('status') == 'error' and not job_active:
-            raise RuntimeError(state.get('message') or f'Cache job failed for video-{quality}')
-
-        if attempt < max_attempts - 1:
-            time.sleep(retry_interval)
-
-    raise TimeoutError(f'Timed out waiting for canonical cache job video-{quality}')
 
 
 def start_video_cache_if_new(url, quality):

--- a/src/addons.py
+++ b/src/addons.py
@@ -34,10 +34,6 @@ class CacheLockStore:
         self.job_lock_path = os.path.join(self.data_dir, f'{media_type}.cache-start.temp')
 
     @staticmethod
-    def _exists(path):
-        return os.path.exists(path)
-
-    @staticmethod
     def _try_acquire(path, cleanup_on_error=False):
         try:
             descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
@@ -66,10 +62,10 @@ class CacheLockStore:
             return False
 
     def media_lock_exists(self):
-        return self._exists(self.media_lock_path)
+        return os.path.exists(self.media_lock_path)
 
     def job_lock_exists(self):
-        return self._exists(self.job_lock_path)
+        return os.path.exists(self.job_lock_path)
 
     def any_lock_exists(self):
         return self.media_lock_exists() or self.job_lock_exists()
@@ -336,24 +332,25 @@ class DownloadProgress:
         if event.get('type') == 'postprocessor' and event.get('status') == 'started' and is_ffmpeg:
             self.encoding()
 
-    def encoding(self):
-        self.state.update({'status': 'encoding', 'percent': 100, 'speed': 0})
+    def _transition(self, **changes):
+        self.state.update(changes)
         self._write(force=True)
+
+    def encoding(self):
+        self._transition(status='encoding', percent=100, speed=0)
 
     def ready(self, file_size):
         file_size = self.number(file_size)
-        self.state.update({
-            'status': 'ready',
-            'percent': 100,
-            'downloaded_bytes': file_size,
-            'total_bytes': file_size,
-            'speed': 0,
-        })
-        self._write(force=True)
+        self._transition(
+            status='ready',
+            percent=100,
+            downloaded_bytes=file_size,
+            total_bytes=file_size,
+            speed=0,
+        )
 
     def error(self, message):
-        self.state.update({'status': 'error', 'message': str(message), 'speed': 0})
-        self._write(force=True)
+        self._transition(status='error', message=str(message), speed=0)
 
 
 
@@ -437,26 +434,25 @@ class YTDLP:
             p.start()
             Processes.setitem(p.pid, [url, f'YT-DLP {logger.yt_id}', time.time()])
             errors = []
-            while p.is_alive():
-                try:
-                    message = q.get(timeout=0.1)
-                except Empty:
-                    continue
+
+            def handle_message(message):
                 if message.get('type') == 'error':
                     errors.append(message.get('message'))
                 elif progress_callback:
                     progress_callback(message)
+
+            while p.is_alive():
+                try:
+                    handle_message(q.get(timeout=0.1))
+                except Empty:
+                    continue
             p.join()
             Processes.rm(p.pid)
             while True:
                 try:
-                    message = q.get_nowait()
+                    handle_message(q.get_nowait())
                 except Empty:
                     break
-                if message.get('type') == 'error':
-                    errors.append(message.get('message'))
-                elif progress_callback:
-                    progress_callback(message)
             for error in errors:
                 logger.error(error)
             logger.info(f'Exited with code {p.exitcode}')
@@ -731,6 +727,10 @@ class MediaDownloader:
             cache_audio_progress.error(error)
             raise
 
+    def _download_with_progress(self):
+        callback = self.progress.handle_ytdlp_event if self.progress else None
+        YTDLP.download(self.url, self.ydl_opts, callback)
+
 
     def video(self):
         if self.meta.get('is_live'): raise NotImplementedError('Livestream transcoding is not supported')
@@ -738,23 +738,25 @@ class MediaDownloader:
 
         height_param = "" if self.media_type.startswith('video-best') else f'[height<={self.res}]'
         if self.timestamps:
-            vid = get_ready_cached_video(self.url, self.cache_quality) if self.cache_quality else None
-            if vid or (vid := check_res_at_least(self.url, self.res)):
+            vid = (
+                get_ready_cached_video(self.url, self.cache_quality) if self.cache_quality else None
+            ) or check_res_at_least(self.url, self.res)
+            if vid:
                 if self.progress: self.progress.encoding()
-                FFMPEG(self.url, ['-i', vid, "-ss", f'{self.start_time}', "-to", f'{self.end_time}', '-vf', f'scale=-2:{self.res}', os.path.join(get_data_dir(self.url), self.media_type + '.mp4')])
+                FFMPEG(self.url, ['-i', vid, "-ss", f'{self.start_time}', "-to", f'{self.end_time}', '-vf', f'scale=-2:{self.res}', os.path.join(self.data_dir, self.media_type + '.mp4')])
             else:
                 self.ydl_opts.update({"format": f"bestvideo{height_param}+bestaudio/best", "outtmpl": os.path.join(self.data_dir, f'{self.media_type}.%(ext)s')})
-                YTDLP.download(self.url, self.ydl_opts, self.progress.handle_ytdlp_event if self.progress else None)
+                self._download_with_progress()
         else:
             if vid := check_res_at_least(self.url, self.res):
                 if self.progress: self.progress.encoding()
-                FFMPEG(self.url, ['-i', vid, '-vf', f'scale=-2:{self.res}', os.path.join(get_data_dir(self.url), self.media_type + '.mp4')])
+                FFMPEG(self.url, ['-i', vid, '-vf', f'scale=-2:{self.res}', os.path.join(self.data_dir, self.media_type + '.mp4')])
             else:
                 success = False
                 temp_video = None
                 try:
                     self.ydl_opts.update({"format": f"bestvideo{height_param}/best", "outtmpl": os.path.join(self.data_dir, f'temp-{self.media_type}.%(ext)s')})
-                    YTDLP.download(self.url, self.ydl_opts, self.progress.handle_ytdlp_event if self.progress else None)
+                    self._download_with_progress()
                     audio_file = check_media(self.url, 'audio') or MediaDownloader(self.url, 'audio').run()
                     temp_video = check_media(self.url, f'temp-{self.media_type}')
                     if not audio_file or not temp_video:
@@ -780,7 +782,7 @@ class MediaDownloader:
                 if not success:
                     print(f'Falling back to standard video download due to FFMPEG error')
                     self.ydl_opts.update({"format": f"bestvideo{height_param}+bestaudio/best", "outtmpl": os.path.join(self.data_dir, f'{self.media_type}.%(ext)s')})
-                    YTDLP.download(self.url, self.ydl_opts, self.progress.handle_ytdlp_event if self.progress else None)
+                    self._download_with_progress()
 
 
     def hls(self):
@@ -1047,13 +1049,17 @@ def stream_media_file(url: str, src: str, headers: str|None = None, cookies: str
             playlist_base_url = response_url
 
             def proxy_playlist_url(resource_url):
-                resolved_url = urljoin(playlist_base_url, resource_url)
-                return f'/external?src={quote_plus(resolved_url)}&headers={quote_plus(headers or "")}&cookies={quote_plus(cookies or "")}&url={quote_plus(url or "")}'
+                query = urlencode({
+                    'src': urljoin(playlist_base_url, resource_url),
+                    'headers': headers or '',
+                    'cookies': cookies or '',
+                    'url': url or '',
+                })
+                return f'/external?{query}'
 
             def replace_src(match):
                 prefix, orig_src, suffix = match.groups()
-                new_src = proxy_playlist_url(orig_src)
-                return f'{prefix}{new_src}{suffix}'
+                return f'{prefix}{proxy_playlist_url(orig_src)}{suffix}'
             raw_lines = response.content.decode('utf-8', errors='ignore').splitlines()
             skipline = False
             for idx, line in enumerate(raw_lines):
@@ -1072,8 +1078,7 @@ def stream_media_file(url: str, src: str, headers: str|None = None, cookies: str
                 if line_str.startswith('#'):
                     lines.append(src_regex.sub(replace_src, line))
                 else:
-                    line = proxy_playlist_url(line_str)
-                    lines.append(line)
+                    lines.append(proxy_playlist_url(line_str))
 
             resp = Response('\n'.join(lines), status=response.status_code, mimetype=mime_type)
             return resp
@@ -1084,10 +1089,9 @@ def stream_media_file(url: str, src: str, headers: str|None = None, cookies: str
 
         resp = Response(generate(), status=response.status_code, mimetype=mime_type)
 
-        if 'Content-Length' in response.headers:
-            resp.headers['Content-Length'] = response.headers['Content-Length']
-        if 'Content-Range' in response.headers:
-            resp.headers['Content-Range'] = response.headers['Content-Range']
+        for header in ('Content-Length', 'Content-Range'):
+            if header in response.headers:
+                resp.headers[header] = response.headers[header]
         resp.headers['Accept-Ranges'] = 'bytes'
         return resp
     except requests.exceptions.RequestException as e:
@@ -1237,25 +1241,27 @@ def probe_media_streams(path: str):
         return None
 
 
+def _has_compatible_video_streams(streams):
+    if streams is None:
+        return False
+    return (
+        any(stream.get('codec_type') == 'video' for stream in streams)
+        and any(stream.get('codec_type') == 'audio' for stream in streams)
+        and not any(
+            stream.get('codec_type') == 'audio'
+            and stream.get('codec_name') in {'mp2', 'mp3'}
+            for stream in streams
+        )
+    )
+
+
 def is_compatible_cached_media(path: str, media_type: str):
     """Reject cached MP4 downloads whose audio codec is not broadly compatible."""
     if not media_type.startswith('video') or os.path.splitext(path)[1].lower() != '.mp4':
         return True
 
     streams = probe_media_streams(path)
-    if streams is None:
-        return True
-    if not any(stream.get('codec_type') == 'video' for stream in streams):
-        return False
-    if not any(stream.get('codec_type') == 'audio' for stream in streams):
-        return False
-
-    incompatible_audio_codecs = {'mp2', 'mp3'}
-    return not any(
-        stream.get('codec_type') == 'audio'
-        and stream.get('codec_name') in incompatible_audio_codecs
-        for stream in streams
-    )
+    return streams is None or _has_compatible_video_streams(streams)
 
 
 def get_ready_cached_video(url: str, quality: str, validate=True):
@@ -1273,18 +1279,7 @@ def get_ready_cached_video(url: str, quality: str, validate=True):
     if not validate:
         return path
 
-    streams = probe_media_streams(path)
-    if streams is None:
-        return None
-    if not any(stream.get('codec_type') == 'video' for stream in streams):
-        return None
-    if not any(stream.get('codec_type') == 'audio' for stream in streams):
-        return None
-    if any(
-        stream.get('codec_type') == 'audio'
-        and stream.get('codec_name') in {'mp2', 'mp3'}
-        for stream in streams
-    ):
+    if not _has_compatible_video_streams(probe_media_streams(path)):
         return None
     return path
 
@@ -1342,17 +1337,18 @@ def read_video_cache_progress(url, quality):
         audio_progress.start()
         audio_state = audio_progress.state
 
+    component_states = (video_state, audio_state)
     downloaded = sum(
         DownloadProgress.number(state.get('downloaded_bytes'))
-        for state in (video_state, audio_state)
+        for state in component_states
     )
     total = sum(
         DownloadProgress.number(state.get('total_bytes'))
-        for state in (video_state, audio_state)
+        for state in component_states
     )
     speed = sum(
         DownloadProgress.number(state.get('speed'))
-        for state in (video_state, audio_state)
+        for state in component_states
         if state.get('status') == 'downloading'
     )
 
@@ -1362,7 +1358,7 @@ def read_video_cache_progress(url, quality):
     percent = min(99, downloaded / total * 100) if total else 0
     status = 'downloading' if any(
         state.get('status') in {'downloading', 'ready'}
-        for state in (video_state, audio_state)
+        for state in component_states
     ) else 'preparing'
 
     return {
@@ -1379,10 +1375,10 @@ def read_video_cache_progress(url, quality):
 
 
 def _cache_video_worker(url, quality):
+    media_type = f'video-{quality}'
     progress = DownloadProgress(url, cache_progress_id(quality))
-    lock_store = CacheLockStore(url, f'video-{quality}')
+    lock_store = CacheLockStore(url, media_type)
     try:
-        media_type = f'video-{quality}'
         cached_video = MediaDownloader(url, media_type, progress).run()
         ready_video = get_ready_cached_video(url, quality)
         if not cached_video or not ready_video:
@@ -1410,10 +1406,7 @@ def ensure_video_cache(url, quality):
     lock_store = CacheLockStore(url, media_type)
     lock_store.remove_stale_job_lock(CACHE_START_MARKER_MAX_AGE)
 
-    if lock_store.any_lock_exists():
-        return read_video_cache_progress(url, quality)
-
-    if not lock_store.try_acquire_job_lock():
+    if lock_store.any_lock_exists() or not lock_store.try_acquire_job_lock():
         return read_video_cache_progress(url, quality)
 
     progress = DownloadProgress(url, cache_progress_id(quality))
@@ -1429,14 +1422,12 @@ def start_video_cache_if_new(url, quality):
         return None
 
     progress_id = cache_progress_id(quality)
-    if DownloadProgress.read(url, progress_id) is not None:
-        return read_video_cache_progress(url, quality)
-
     media_type = f'video-{quality}'
-    if CacheLockStore(url, media_type).any_lock_exists():
-        return read_video_cache_progress(url, quality)
-
-    if get_ready_cached_video(url, quality):
+    if (
+        DownloadProgress.read(url, progress_id) is not None
+        or CacheLockStore(url, media_type).any_lock_exists()
+        or get_ready_cached_video(url, quality)
+    ):
         return read_video_cache_progress(url, quality)
 
     return ensure_video_cache(url, quality)

--- a/src/addons.py
+++ b/src/addons.py
@@ -215,49 +215,8 @@ class Processes:
 
 
 
-class CacheProgressStore:
-    """Filesystem store for cache-job progress records."""
-
-    def __init__(self, url, progress_id):
-        self.progress_id = progress_id if self.valid_id(progress_id) else None
-        self.path = self.get_path(url, self.progress_id) if self.progress_id else None
-
-    @staticmethod
-    def valid_id(progress_id):
-        return isinstance(progress_id, str) and re.fullmatch(r'[A-Za-z0-9_-]{1,80}', progress_id) is not None
-
-    @staticmethod
-    def get_path(url, progress_id):
-        return os.path.join(get_data_dir(url), f'download-progress-{progress_id}.json')
-
-    def read(self):
-        if not self.path:
-            return None
-        try:
-            with open(self.path, 'r') as progress_file:
-                return json.load(progress_file)
-        except (FileNotFoundError, json.JSONDecodeError):
-            return None
-
-    def write(self, state):
-        if not self.path:
-            return
-
-        os.makedirs(os.path.dirname(self.path), exist_ok=True)
-        temp_path = f'{self.path}.{os.getpid()}.{time.time_ns()}.temp'
-        try:
-            with open(temp_path, 'w') as progress_file:
-                json.dump(state, progress_file)
-            os.replace(temp_path, self.path)
-        finally:
-            try:
-                os.remove(temp_path)
-            except FileNotFoundError:
-                pass
-
-
 class DownloadProgress:
-    """Tracks cache-job progress and delegates its persistence to the store."""
+    """Persists download progress so it can be read by any web worker."""
 
     update_interval = 0.2
     ffmpeg_postprocessors = {
@@ -269,9 +228,8 @@ class DownloadProgress:
 
     def __init__(self, url: str, progress_id: str | None):
         self.url = url
-        self.store = CacheProgressStore(url, progress_id)
-        self.progress_id = self.store.progress_id
-        self.path = self.store.path
+        self.progress_id = progress_id if self.valid_id(progress_id) else None
+        self.path = self.get_path(url, self.progress_id) if self.progress_id else None
         self.last_write = 0
         self.state = self.initial_state()
 
@@ -287,24 +245,36 @@ class DownloadProgress:
 
     @staticmethod
     def valid_id(progress_id):
-        return CacheProgressStore.valid_id(progress_id)
+        return isinstance(progress_id, str) and re.fullmatch(r'[A-Za-z0-9_-]{1,80}', progress_id) is not None
 
     @staticmethod
     def get_path(url, progress_id):
-        return CacheProgressStore.get_path(url, progress_id)
+        return os.path.join(get_data_dir(url), f'download-progress-{progress_id}.json')
 
     @classmethod
     def read(cls, url, progress_id):
-        return CacheProgressStore(url, progress_id).read()
+        if not cls.valid_id(progress_id): return None
+        try:
+            with open(cls.get_path(url, progress_id), 'r') as f:
+                return json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return None
 
     def _write(self, force=False):
-        if not self.progress_id: return
+        if not self.path: return
         now = time.time()
         if not force and now - self.last_write < self.update_interval: return
 
         self.last_write = now
         self.state['timestamp'] = now
-        self.store.write(self.state)
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        temp_path = f'{self.path}.{os.getpid()}.{time.time_ns()}.temp'
+        try:
+            with open(temp_path, 'w') as f:
+                json.dump(self.state, f)
+            os.replace(temp_path, self.path)
+        finally:
+            if os.path.exists(temp_path): os.remove(temp_path)
 
     def start(self):
         self._write(force=True)
@@ -1343,7 +1313,7 @@ def read_video_cache_progress(url, quality):
         return None
 
     progress = DownloadProgress(url, progress_id)
-    video_state = CacheProgressStore(url, progress_id).read() or DownloadProgress.initial_state()
+    video_state = DownloadProgress.read(url, progress_id) or DownloadProgress.initial_state()
     ready_video = get_ready_cached_video(url, quality)
     if ready_video:
         file_size = os.path.getsize(ready_video)
@@ -1361,7 +1331,7 @@ def read_video_cache_progress(url, quality):
         return video_state
 
     audio_progress = DownloadProgress(url, CACHE_AUDIO_PROGRESS_ID)
-    audio_state = CacheProgressStore(url, CACHE_AUDIO_PROGRESS_ID).read() or DownloadProgress.initial_state()
+    audio_state = DownloadProgress.read(url, CACHE_AUDIO_PROGRESS_ID) or DownloadProgress.initial_state()
     audio_file = _find_cached_media(url, 'audio')
     if audio_file:
         audio_size = os.path.getsize(audio_file)
@@ -1459,7 +1429,7 @@ def start_video_cache_if_new(url, quality):
         return None
 
     progress_id = cache_progress_id(quality)
-    if CacheProgressStore(url, progress_id).read() is not None:
+    if DownloadProgress.read(url, progress_id) is not None:
         return read_video_cache_progress(url, quality)
 
     media_type = f'video-{quality}'

--- a/src/addons.py
+++ b/src/addons.py
@@ -11,6 +11,7 @@ import io
 import requests
 import shutil
 import struct
+from queue import Empty
 from PIL import Image
 from datetime import datetime
 from hashlib import sha1
@@ -25,34 +26,66 @@ yt_dlp = External.yt_dlp()
 
 
 class FileCachingLock:
+    max_wait_attempts = 600
+    retry_interval_seconds = 1
+
     def __init__(self, url, media_type):
         self.url = url
         self.media_type = media_type
         self.data_dir = get_data_dir(url)
+        self.lock_path = os.path.join(self.data_dir, f'{self.media_type}.temp')
+        self.acquired = False
 
     def __enter__(self):
-        for _ in range(600):
-            if not os.path.exists(os.path.join(self.data_dir, f'{self.media_type}.temp')):
-                break
-            time.sleep(1)
-            print(f'Waiting for download of {self.media_type} for {self.data_dir.split("/")[-1]}')
-        
-        if cached_media := check_media(url=self.url, media_type=self.media_type):
-            print(f'Cache hit for {self.media_type}!')
-            self.url = None
-            return cached_media
-        
         os.makedirs(self.data_dir, exist_ok=True)
-        keepalive(self.data_dir)
-        with open(os.path.join(self.data_dir, f'{self.media_type}.temp'), 'w') as f:
-            f.write(datetime.now().isoformat())
-        
-        return None
+        for attempt in range(self.max_wait_attempts):
+            try:
+                descriptor = os.open(self.lock_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+            except FileExistsError:
+                if attempt == self.max_wait_attempts - 1:
+                    raise TimeoutError(
+                        f'Timed out waiting for download of {self.media_type} '
+                        f'for {os.path.basename(self.data_dir)}'
+                    )
+                print(f'Waiting for download of {self.media_type} for {os.path.basename(self.data_dir)}')
+                time.sleep(self.retry_interval_seconds)
+                continue
+
+            self.acquired = True
+            try:
+                with os.fdopen(descriptor, 'w') as lock_file:
+                    lock_file.write(datetime.now().isoformat())
+                keepalive(self.data_dir)
+                if cached_media := check_media(url=self.url, media_type=self.media_type):
+                    if is_compatible_cached_media(cached_media, self.media_type):
+                        print(f'Cache hit for {self.media_type}!')
+                        return cached_media
+                    print(f'Removing incompatible cached media: {cached_media}')
+                    try:
+                        os.remove(cached_media)
+                    except FileNotFoundError:
+                        pass
+                return None
+            except Exception:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+                self._release()
+                raise
+
+    def _release(self):
+        if not self.acquired:
+            return
+        try:
+            os.remove(self.lock_path)
+        except FileNotFoundError:
+            print(f'FATAL ERROR trying to unlock {self.media_type} of {self.data_dir}. Media type cannot be downloaded')
+        finally:
+            self.acquired = False
 
     def __exit__(self, exc_type, exc_value, traceback):
-        if self.url:
-            try: os.remove(os.path.join(self.data_dir, f'{self.media_type}.temp'))
-            except: print(f'FATAL ERROR trying to unlock {self.media_type} of {self.data_dir}. Media type cannot be downloaded')
+        self._release()
 
 
 
@@ -117,6 +150,148 @@ class Processes:
 
 
 
+class DownloadProgress:
+    """Persists download progress so it can be read by any web worker."""
+
+    update_interval = 0.2
+    ffmpeg_postprocessors = {
+        'ExtractAudio',
+        'Merger',
+        'VideoConvertor',
+        'VideoRemuxer',
+    }
+
+    def __init__(self, url: str, progress_id: str | None):
+        self.url = url
+        self.progress_id = progress_id if self.valid_id(progress_id) else None
+        self.path = self.get_path(url, self.progress_id) if self.progress_id else None
+        self.last_write = 0
+        self.state = self.initial_state()
+
+    @staticmethod
+    def initial_state():
+        return {
+            'status': 'preparing',
+            'percent': 0,
+            'downloaded_bytes': 0,
+            'total_bytes': 0,
+            'speed': 0,
+        }
+
+    @staticmethod
+    def valid_id(progress_id):
+        return isinstance(progress_id, str) and re.fullmatch(r'[A-Za-z0-9_-]{1,80}', progress_id) is not None
+
+    @staticmethod
+    def get_path(url, progress_id):
+        return os.path.join(get_data_dir(url), f'download-progress-{progress_id}.json')
+
+    @classmethod
+    def read(cls, url, progress_id):
+        if not cls.valid_id(progress_id): return None
+        try:
+            with open(cls.get_path(url, progress_id), 'r') as f:
+                return json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return None
+
+    def _write(self, force=False):
+        if not self.path: return
+        now = time.time()
+        if not force and now - self.last_write < self.update_interval: return
+
+        self.last_write = now
+        self.state['timestamp'] = now
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        temp_path = f'{self.path}.{os.getpid()}.{time.time_ns()}.temp'
+        try:
+            with open(temp_path, 'w') as f:
+                json.dump(self.state, f)
+            os.replace(temp_path, self.path)
+        finally:
+            if os.path.exists(temp_path): os.remove(temp_path)
+
+    def start(self):
+        self._write(force=True)
+
+    @staticmethod
+    def _number(value, default=0):
+        try:
+            value = float(value)
+            return value if math.isfinite(value) and value >= 0 else default
+        except (TypeError, ValueError):
+            return default
+
+    def download(self, data):
+        previous_status = self.state.get('status')
+        downloaded = self._number(data.get('downloaded_bytes'))
+        total = self._number(
+            data.get('total_bytes')
+            or data.get('total_bytes_estimate')
+            or data.get('filesize')
+            or data.get('filesize_approx')
+        )
+        speed = self._number(data.get('speed'), self.state.get('speed', 0))
+        status = data.get('status')
+
+        if not total:
+            fragment_index = self._number(data.get('fragment_index'))
+            fragment_count = self._number(data.get('fragment_count'))
+            if fragment_index and fragment_count:
+                total = downloaded * fragment_count / fragment_index
+
+        if status == 'finished':
+            total = max(total, downloaded)
+            percent = 100
+        elif total:
+            total = max(total, downloaded)
+            percent = min(100, downloaded / total * 100)
+        else:
+            percent = 0
+
+        self.state.update({
+            'status': 'downloading',
+            'percent': percent,
+            'downloaded_bytes': downloaded,
+            'total_bytes': total,
+            'speed': speed,
+        })
+        self._write(force=status == 'finished' or previous_status != 'downloading')
+
+    def handle_ytdlp_event(self, event):
+        if event.get('type') == 'download':
+            self.download(event)
+            return
+
+        postprocessor = event.get('postprocessor') or ''
+        # HLS downloads commonly run a FixupM3u8 postprocessor after the video
+        # fragments finish. That is not the final audio/video cache merge, so it
+        # must not make the UI claim that the completed video is being encoded.
+        is_ffmpeg = postprocessor in self.ffmpeg_postprocessors
+        if event.get('type') == 'postprocessor' and event.get('status') == 'started' and is_ffmpeg:
+            self.encoding()
+
+    def encoding(self):
+        self.state.update({'status': 'encoding', 'percent': 100, 'speed': 0})
+        self._write(force=True)
+
+    def ready(self, file_size):
+        file_size = self._number(file_size)
+        self.state.update({
+            'status': 'ready',
+            'percent': 100,
+            'downloaded_bytes': file_size,
+            'total_bytes': file_size,
+            'speed': 0,
+        })
+        self._write(force=True)
+
+    def error(self, message):
+        self.state.update({'status': 'error', 'message': str(message), 'speed': 0})
+        self._write(force=True)
+
+
+
 class YTDLP:
 
     class Logger:
@@ -146,21 +321,48 @@ class YTDLP:
     @staticmethod
     def _ydl_runner(url, opts, with_info, arg, queue, yt_id = None):
         logger = YTDLP.Logger(url, opts, 'download', yt_id)
+        def progress_hook(data):
+            info = data.get('info_dict') or {}
+            queue.put({
+                'type': 'download',
+                'status': data.get('status'),
+                'downloaded_bytes': data.get('downloaded_bytes'),
+                'total_bytes': data.get('total_bytes'),
+                'total_bytes_estimate': data.get('total_bytes_estimate'),
+                'speed': data.get('speed'),
+                'fragment_index': data.get('fragment_index'),
+                'fragment_count': data.get('fragment_count'),
+                'filesize': info.get('filesize'),
+                'filesize_approx': info.get('filesize_approx'),
+            })
+
+        def postprocessor_hook(data):
+            queue.put({
+                'type': 'postprocessor',
+                'status': data.get('status'),
+                'postprocessor': data.get('postprocessor'),
+            })
+
         try:
             if ffmpeg: os.environ['PATH'] += os.path.dirname(ffmpeg)
             if js_runtime: os.environ['PATH'] += os.path.dirname(js_runtime)
-            with yt_dlp.YoutubeDL(opts | {'logger': logger}) as ydl:
+            runner_opts = opts | {'logger': logger}
+            runner_opts['progress_hooks'] = [*(runner_opts.get('progress_hooks') or []), progress_hook]
+            runner_opts['postprocessor_hooks'] = [*(runner_opts.get('postprocessor_hooks') or []), postprocessor_hook]
+            with yt_dlp.YoutubeDL(runner_opts) as ydl:
                 if with_info:
                     ydl.download_with_info_file(arg)
                 else:
                     ydl.download(arg)
         except Exception as e:
-            queue.put(f'{e}')
-        logger.finish()
+            queue.put({'type': 'error', 'message': f'{e}'})
+            raise
+        finally:
+            logger.finish()
 
 
     @staticmethod
-    def download(url, opts):
+    def download(url, opts, progress_callback=None):
         if (proxy): opts["proxy"] = proxy
         logger = YTDLP.Logger(url, opts, 'download')
         def ydl_download(url, opts, with_info = False):
@@ -169,11 +371,31 @@ class YTDLP:
             p = Process(target=YTDLP._ydl_runner, args=(url, opts, with_info, arg, q, logger.yt_id))
             p.start()
             Processes.setitem(p.pid, [url, f'YT-DLP {logger.yt_id}', time.time()])
+            errors = []
+            while p.is_alive():
+                try:
+                    message = q.get(timeout=0.1)
+                except Empty:
+                    continue
+                if message.get('type') == 'error':
+                    errors.append(message.get('message'))
+                elif progress_callback:
+                    progress_callback(message)
             p.join()
             Processes.rm(p.pid)
-            while not q.empty():
-                logger.error(q.get())
+            while True:
+                try:
+                    message = q.get_nowait()
+                except Empty:
+                    break
+                if message.get('type') == 'error':
+                    errors.append(message.get('message'))
+                elif progress_callback:
+                    progress_callback(message)
+            for error in errors:
+                logger.error(error)
             logger.info(f'Exited with code {p.exitcode}')
+            if errors: raise RuntimeError(errors[-1])
             if p.exitcode != 0: raise RuntimeError(f'YT-DLP exited unexpectedly with return code {p.exitcode}')
 
         try:
@@ -276,10 +498,11 @@ class FFMPEG:
 
 
 class MediaDownloader:
-    def __init__(self, url: str, media_type: str):
+    def __init__(self, url: str, media_type: str, progress: DownloadProgress | None = None):
         self.url = re.sub(r'(https?):/{1,}', r'\1://', url)
         self.data_dir = get_data_dir(self.url)
         self.media_type = media_type
+        self.progress = progress
         os.makedirs(self.data_dir, exist_ok=True)
 
 
@@ -310,7 +533,9 @@ class MediaDownloader:
         self.timestamps = re.search(r'_(\d+\.?\d*)-(\d+\.?\d*)', self.media_type)
         self.start_time = None
         self.end_time = None
-        selected_res = re.search(r'(\d+)', self.media_type) and re.search(r'(\d+)', self.media_type).group(1)
+        quality_match = re.match(r'video-(best|\d+)', self.media_type)
+        self.cache_quality = quality_match.group(1) if quality_match else None
+        selected_res = self.cache_quality if self.cache_quality and self.cache_quality.isdigit() else None
         self.res = int(selected_res or get_good_quality(get_video_formats(meta=self.meta)))
 
         if self.timestamps:
@@ -415,8 +640,31 @@ class MediaDownloader:
 
     def audio(self):
         if self.meta.get('is_live'): raise NotImplementedError('Livestream transcoding is not supported')
-        self.ydl_opts.update({"format": "bestaudio/best", "extract_audio": True, "outtmpl": os.path.join(self.data_dir, f'{self.media_type}.mp3')})
-        YTDLP.download(self.url, self.ydl_opts)
+        self.ydl_opts.update({
+            "format": "bestaudio/best",
+            "outtmpl": os.path.join(self.data_dir, f'{self.media_type}.%(ext)s'),
+            "postprocessors": [{"key": "FFmpegExtractAudio", "preferredcodec": "mp3"}],
+        })
+        cache_audio_progress = DownloadProgress(self.url, CACHE_AUDIO_PROGRESS_ID)
+        cache_audio_progress.start()
+
+        def handle_audio_progress(event):
+            # Audio extraction is still part of preparing the cache inputs. Only
+            # publish byte-download events here; the final merge sets encoding.
+            if event.get('type') == 'download':
+                cache_audio_progress.download(event)
+            if self.progress and self.progress.progress_id != CACHE_AUDIO_PROGRESS_ID:
+                self.progress.handle_ytdlp_event(event)
+
+        try:
+            YTDLP.download(self.url, self.ydl_opts, handle_audio_progress)
+            audio_file = _find_cached_media(self.url, 'audio')
+            if not audio_file:
+                raise RuntimeError('YT-DLP did not produce a complete audio file')
+            cache_audio_progress.ready(os.path.getsize(audio_file))
+        except Exception as error:
+            cache_audio_progress.error(error)
+            raise
 
 
     def video(self):
@@ -425,23 +673,41 @@ class MediaDownloader:
 
         height_param = "" if self.media_type.startswith('video-best') else f'[height<={self.res}]'
         if self.timestamps:
-            if vid := check_res_at_least(self.url, self.res):
+            vid = get_ready_cached_video(self.url, self.cache_quality) if self.cache_quality else None
+            if vid or (vid := check_res_at_least(self.url, self.res)):
+                if self.progress: self.progress.encoding()
                 FFMPEG(self.url, ['-i', vid, "-ss", f'{self.start_time}', "-to", f'{self.end_time}', '-vf', f'scale=-2:{self.res}', os.path.join(get_data_dir(self.url), self.media_type + '.mp4')])
             else:
                 self.ydl_opts.update({"format": f"bestvideo{height_param}+bestaudio/best", "outtmpl": os.path.join(self.data_dir, f'{self.media_type}.%(ext)s')})
-                YTDLP.download(self.url, self.ydl_opts)
+                YTDLP.download(self.url, self.ydl_opts, self.progress.handle_ytdlp_event if self.progress else None)
         else:
             if vid := check_res_at_least(self.url, self.res):
+                if self.progress: self.progress.encoding()
                 FFMPEG(self.url, ['-i', vid, '-vf', f'scale=-2:{self.res}', os.path.join(get_data_dir(self.url), self.media_type + '.mp4')])
             else:
                 success = False
                 temp_video = None
                 try:
                     self.ydl_opts.update({"format": f"bestvideo{height_param}/best", "outtmpl": os.path.join(self.data_dir, f'temp-{self.media_type}.%(ext)s')})
-                    YTDLP.download(self.url, self.ydl_opts)
+                    YTDLP.download(self.url, self.ydl_opts, self.progress.handle_ytdlp_event if self.progress else None)
                     audio_file = check_media(self.url, 'audio') or MediaDownloader(self.url, 'audio').run()
                     temp_video = check_media(self.url, f'temp-{self.media_type}')
-                    success = FFMPEG(self.url, ['-i', audio_file, '-i', temp_video, "-c:a", "copy", "-c:v", "copy", temp_video.replace('temp-', '')]).success
+                    if not audio_file or not temp_video:
+                        raise RuntimeError('YT-DLP did not produce complete audio and video files')
+                    output_name = os.path.splitext(os.path.basename(temp_video).removeprefix('temp-'))[0] + '.mp4'
+                    output_file = os.path.join(os.path.dirname(temp_video), output_name)
+                    if self.progress: self.progress.encoding()
+                    success = FFMPEG(self.url, [
+                        '-i', audio_file,
+                        '-i', temp_video,
+                        '-map', '1:v:0',
+                        '-map', '0:a:0',
+                        '-c:v', 'copy',
+                        '-c:a', 'aac',
+                        '-b:a', '192k',
+                        '-movflags', '+faststart',
+                        output_file,
+                    ]).success
                 except Exception as e:
                     pprint_exc(e)
                 finally:
@@ -449,7 +715,7 @@ class MediaDownloader:
                 if not success:
                     print(f'Falling back to standard video download due to FFMPEG error')
                     self.ydl_opts.update({"format": f"bestvideo{height_param}+bestaudio/best", "outtmpl": os.path.join(self.data_dir, f'{self.media_type}.%(ext)s')})
-                    YTDLP.download(self.url, self.ydl_opts)
+                    YTDLP.download(self.url, self.ydl_opts, self.progress.handle_ytdlp_event if self.progress else None)
 
 
     def hls(self):
@@ -705,13 +971,23 @@ def stream_media_file(url: str, src: str, headers: str|None = None, cookies: str
         response.raise_for_status()
         mime_type = response.headers.get('Content-Type', 'application/octet-stream')
 
-        if 'mpegurl' in mime_type.lower():
+        response_url = getattr(response, 'url', None) or src
+        is_hls_playlist = (
+            'mpegurl' in mime_type.lower()
+            or urlparse(response_url).path.lower().endswith('.m3u8')
+        )
+        if is_hls_playlist:
             lines = []
             src_regex = re.compile(r'(URI=["\'])([^"\']*)(["\'])')
+            playlist_base_url = response_url
+
+            def proxy_playlist_url(resource_url):
+                resolved_url = urljoin(playlist_base_url, resource_url)
+                return f'/external?src={quote_plus(resolved_url)}&headers={quote_plus(headers or "")}&cookies={quote_plus(cookies or "")}&url={quote_plus(url or "")}'
 
             def replace_src(match):
                 prefix, orig_src, suffix = match.groups()
-                new_src = f'/external?src={quote_plus(urljoin(src, orig_src))}&headers={quote_plus(headers or "")}&cookies={quote_plus(cookies or "")}&url={quote_plus(url)}'
+                new_src = proxy_playlist_url(orig_src)
                 return f'{prefix}{new_src}{suffix}'
             raw_lines = response.content.decode('utf-8', errors='ignore').splitlines()
             skipline = False
@@ -731,7 +1007,7 @@ def stream_media_file(url: str, src: str, headers: str|None = None, cookies: str
                 if line_str.startswith('#'):
                     lines.append(src_regex.sub(replace_src, line))
                 else:
-                    line = f'/external?src={quote_plus(urljoin(url, line_str))}&headers={quote_plus(headers or "")}&cookies={quote_plus(cookies or "")}&url={quote_plus(url)}'
+                    line = proxy_playlist_url(line_str)
                     lines.append(line)
 
             resp = Response('\n'.join(lines), status=response.status_code, mimetype=mime_type)
@@ -757,47 +1033,18 @@ def stream_media_file(url: str, src: str, headers: str|None = None, cookies: str
 
 
 def send_file_partial(path, download_name: str | None = None):
-    """ 
-        Simple wrapper around send_file which handles HTTP 206 Partial Content
-        (byte ranges)
-        TODO: handle all send_file args, mirror send_file's error handling
-        (if it has any)
-    """
-    range_header = request.headers.get('Range')
-    if not range_header: return send_file(path, download_name=download_name)
-    
-    size = os.path.getsize(path)    
-    byte1, byte2 = 0, None
-    
-    m = re.search(r'(\d+)-(\d*)', range_header)
-    g = m.groups()
-    
-    if g[0]: byte1 = int(g[0])
-    if g[1]: byte2 = int(g[1])
-
-    length = size - byte1
-    if byte2 is not None:
-        length = byte2 - byte1
-    
-    data = None
-    with open(path, 'rb') as f:
-        f.seek(byte1)
-        data = f.read(length)
-
-    rv = Response(data, 
-        206,
-        mimetype=mimetypes.guess_type(path)[0], 
-        direct_passthrough=True)
-    rv.headers.add('Content-Range', 'bytes {0}-{1}/{2}'.format(byte1, byte1 + length - 1, size))
-
-    return rv
+    """Serve local media with Flask's conditional byte-range support."""
+    response = send_file(path, download_name=download_name, conditional=True)
+    response.headers['Accept-Ranges'] = 'bytes'
+    return response
 
 
 
-def host_file(url: str, media_type='video', download_name: str | None = None):
+def host_file(url: str, media_type='video', download_name: str | None = None, progress: DownloadProgress | None = None):
     if not url: return jsonify({"error": "URL parameter is required"}), 400
-    file = MediaDownloader(url, media_type).run()
+    file = MediaDownloader(url, media_type, progress).run()
     if file:
+        if progress: progress.ready(os.path.getsize(file))
         if download_name:
             if '-' in media_type: download_name += '-' + media_type.split('-', 1)[-1]
             download_name += os.path.splitext(file)[1]
@@ -897,6 +1144,295 @@ def get_data_dir(url):
     return data_dir
 
 
+def probe_media_streams(path: str):
+    ffprobe = shutil.which('ffprobe')
+    if not ffprobe and ffmpeg:
+        candidate = os.path.join(os.path.dirname(ffmpeg), 'ffprobe')
+        if os.path.exists(candidate):
+            ffprobe = candidate
+    if not ffprobe:
+        print(f'FFprobe unavailable; cannot inspect {path}')
+        return None
+
+    try:
+        result = subprocess.run([
+            ffprobe,
+            '-v', 'error',
+            '-show_entries', 'stream=codec_type,codec_name',
+            '-of', 'json',
+            path,
+        ], capture_output=True, text=True, timeout=10)
+        if result.returncode != 0:
+            print(f'FFprobe could not inspect {path}: {result.stderr.strip()}')
+            return None
+
+        return json.loads(result.stdout).get('streams') or []
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as error:
+        print(f'Could not inspect media {path}: {error}')
+        return None
+
+
+def is_compatible_cached_media(path: str, media_type: str):
+    """Reject cached MP4 downloads whose audio codec is not broadly compatible."""
+    if not media_type.startswith('video') or os.path.splitext(path)[1].lower() != '.mp4':
+        return True
+
+    streams = probe_media_streams(path)
+    if streams is None:
+        return True
+    if not any(stream.get('codec_type') == 'video' for stream in streams):
+        return False
+    if not any(stream.get('codec_type') == 'audio' for stream in streams):
+        return False
+
+    incompatible_audio_codecs = {'mp2', 'mp3'}
+    return not any(
+        stream.get('codec_type') == 'audio'
+        and stream.get('codec_name') in incompatible_audio_codecs
+        for stream in streams
+    )
+
+
+def get_ready_cached_video(url: str, quality: str, validate=True):
+    """Return a complete local MP4 with video and audio, without waiting on an active cache job."""
+    if not quality or quality == 'audio':
+        return None
+
+    media_type = f'video-{quality}'
+    data_dir = get_data_dir(url)
+    if os.path.exists(os.path.join(data_dir, f'{media_type}.temp')):
+        return None
+
+    path = check_media(url, media_type)
+    if not path or os.path.splitext(path)[1].lower() != '.mp4':
+        return None
+    if not validate:
+        return path
+
+    streams = probe_media_streams(path)
+    if streams is None:
+        return None
+    if not any(stream.get('codec_type') == 'video' for stream in streams):
+        return None
+    if not any(stream.get('codec_type') == 'audio' for stream in streams):
+        return None
+    if any(
+        stream.get('codec_type') == 'audio'
+        and stream.get('codec_name') in {'mp2', 'mp3'}
+        for stream in streams
+    ):
+        return None
+    return path
+
+
+CACHE_PROGRESS_PREFIX = 'cache-'
+CACHE_AUDIO_PROGRESS_ID = f'{CACHE_PROGRESS_PREFIX}audio'
+CACHE_START_MARKER_MAX_AGE = 30
+CACHE_WAIT_MAX_ATTEMPTS = 600
+CACHE_WAIT_INTERVAL_SECONDS = 1
+
+
+def normalize_cache_quality(quality):
+    quality = str(quality or '')
+    if quality == 'best' or re.fullmatch(r'\d{1,4}', quality):
+        return quality
+    return None
+
+
+def cache_progress_id(quality):
+    quality = normalize_cache_quality(quality)
+    return f'{CACHE_PROGRESS_PREFIX}{quality}' if quality else None
+
+
+def read_video_cache_progress(url, quality):
+    """Return aggregate video + audio cache progress for a validated MP4."""
+    progress_id = cache_progress_id(quality)
+    if not progress_id:
+        return None
+
+    progress = DownloadProgress(url, progress_id)
+    video_state = DownloadProgress.read(url, progress_id) or DownloadProgress.initial_state()
+    ready_video = get_ready_cached_video(url, quality)
+    if ready_video:
+        file_size = os.path.getsize(ready_video)
+        if video_state.get('status') != 'ready' or video_state.get('total_bytes') != file_size:
+            progress.ready(file_size)
+            video_state = progress.state
+        return video_state
+
+    if video_state.get('status') == 'ready':
+        video_state = DownloadProgress.initial_state()
+
+    # These states describe the cache job as a whole and must take precedence
+    # over its individual download components.
+    if video_state.get('status') in {'encoding', 'error'}:
+        return video_state
+
+    audio_progress = DownloadProgress(url, CACHE_AUDIO_PROGRESS_ID)
+    audio_state = DownloadProgress.read(url, CACHE_AUDIO_PROGRESS_ID) or DownloadProgress.initial_state()
+    audio_file = _find_cached_media(url, 'audio')
+    if audio_file:
+        audio_size = os.path.getsize(audio_file)
+        if audio_state.get('status') != 'ready' or audio_state.get('total_bytes') != audio_size:
+            audio_progress.ready(audio_size)
+            audio_state = audio_progress.state
+    elif audio_state.get('status') == 'ready':
+        audio_progress.start()
+        audio_state = audio_progress.state
+
+    downloaded = sum(
+        DownloadProgress._number(state.get('downloaded_bytes'))
+        for state in (video_state, audio_state)
+    )
+    total = sum(
+        DownloadProgress._number(state.get('total_bytes'))
+        for state in (video_state, audio_state)
+    )
+    speed = sum(
+        DownloadProgress._number(state.get('speed'))
+        for state in (video_state, audio_state)
+        if state.get('status') == 'downloading'
+    )
+
+    # Until the final MP4 exists, reserve 100% for the transition to the actual
+    # FFmpeg merge. This also avoids showing 100% while the audio size is not yet
+    # known or while both downloaded inputs are waiting to be merged.
+    percent = min(99, downloaded / total * 100) if total else 0
+    status = 'downloading' if any(
+        state.get('status') in {'downloading', 'ready'}
+        for state in (video_state, audio_state)
+    ) else 'preparing'
+
+    return {
+        'status': status,
+        'percent': percent,
+        'downloaded_bytes': downloaded,
+        'total_bytes': total,
+        'speed': speed,
+        'timestamp': max(
+            DownloadProgress._number(video_state.get('timestamp')),
+            DownloadProgress._number(audio_state.get('timestamp')),
+        ),
+    }
+
+
+def _cache_video_worker(url, quality, start_marker):
+    progress = DownloadProgress(url, cache_progress_id(quality))
+    try:
+        media_type = f'video-{quality}'
+        cached_video = MediaDownloader(url, media_type, progress).run()
+        ready_video = get_ready_cached_video(url, quality)
+        if not cached_video or not ready_video:
+            raise RuntimeError(f'Cache did not produce a ready MP4 for {media_type}')
+        progress.ready(os.path.getsize(ready_video))
+    except Exception as error:
+        pprint_exc(error)
+        progress.error(error)
+    finally:
+        try:
+            os.remove(start_marker)
+        except FileNotFoundError:
+            pass
+
+
+def ensure_video_cache(url, quality):
+    """Start one persistent background cache job and return its current state."""
+    quality = normalize_cache_quality(quality)
+    if not url or not quality:
+        return None
+
+    if ready_video := get_ready_cached_video(url, quality):
+        progress = DownloadProgress(url, cache_progress_id(quality))
+        progress.ready(os.path.getsize(ready_video))
+        return progress.state
+
+    data_dir = get_data_dir(url)
+    os.makedirs(data_dir, exist_ok=True)
+    media_type = f'video-{quality}'
+    media_lock = os.path.join(data_dir, f'{media_type}.temp')
+    start_marker = os.path.join(data_dir, f'{media_type}.cache-start.temp')
+
+    if os.path.exists(start_marker) and not os.path.exists(media_lock):
+        try:
+            if time.time() - os.path.getmtime(start_marker) > CACHE_START_MARKER_MAX_AGE:
+                os.remove(start_marker)
+        except FileNotFoundError:
+            pass
+
+    if os.path.exists(media_lock) or os.path.exists(start_marker):
+        return read_video_cache_progress(url, quality)
+
+    try:
+        descriptor = os.open(start_marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+    except FileExistsError:
+        return read_video_cache_progress(url, quality)
+
+    with os.fdopen(descriptor, 'w') as marker_file:
+        marker_file.write(datetime.now().isoformat())
+
+    progress = DownloadProgress(url, cache_progress_id(quality))
+    progress.start()
+    Thread(target=_cache_video_worker, args=(url, quality, start_marker), daemon=True).start()
+    return progress.state
+
+
+def wait_for_video_cache(
+    url,
+    quality,
+    max_attempts=CACHE_WAIT_MAX_ATTEMPTS,
+    retry_interval=CACHE_WAIT_INTERVAL_SECONDS,
+):
+    """Wait for the canonical cache job instead of starting a second downloader."""
+    quality = normalize_cache_quality(quality)
+    if not url or not quality:
+        return None
+
+    ensure_video_cache(url, quality)
+    data_dir = get_data_dir(url)
+    media_type = f'video-{quality}'
+    media_lock = os.path.join(data_dir, f'{media_type}.temp')
+    start_marker = os.path.join(data_dir, f'{media_type}.cache-start.temp')
+
+    for attempt in range(max_attempts):
+        if ready_video := get_ready_cached_video(url, quality):
+            progress = DownloadProgress(url, cache_progress_id(quality))
+            progress.ready(os.path.getsize(ready_video))
+            return ready_video
+
+        state = read_video_cache_progress(url, quality) or DownloadProgress.initial_state()
+        job_active = os.path.exists(media_lock) or os.path.exists(start_marker)
+        if state.get('status') == 'error' and not job_active:
+            raise RuntimeError(state.get('message') or f'Cache job failed for video-{quality}')
+
+        if attempt < max_attempts - 1:
+            time.sleep(retry_interval)
+
+    raise TimeoutError(f'Timed out waiting for canonical cache job video-{quality}')
+
+
+def start_video_cache_if_new(url, quality):
+    """Start a cache job only when this URL and quality have no prior cache state."""
+    quality = normalize_cache_quality(quality)
+    if not url or not quality:
+        return None
+
+    progress_id = cache_progress_id(quality)
+    if DownloadProgress.read(url, progress_id) is not None:
+        return read_video_cache_progress(url, quality)
+
+    data_dir = get_data_dir(url)
+    media_type = f'video-{quality}'
+    media_lock = os.path.join(data_dir, f'{media_type}.temp')
+    start_marker = os.path.join(data_dir, f'{media_type}.cache-start.temp')
+    if os.path.exists(media_lock) or os.path.exists(start_marker):
+        return read_video_cache_progress(url, quality)
+
+    if get_ready_cached_video(url, quality):
+        return read_video_cache_progress(url, quality)
+
+    return ensure_video_cache(url, quality)
+
+
 def get_global_cookies_file(force = False):
     if cookies_only_on_failure and not force: return None
     if os.path.exists('cookies.txt'): return 'cookies.txt'
@@ -908,24 +1444,29 @@ def keepalive(data_dir):
         f.write(str(int(time.time())))
 
 
-def check_media(url: str, media_type: str):
-    print(f'Checking media for {url=} and {media_type=}')
+def _find_cached_media(url: str, media_type: str):
     data_dir = get_data_dir(url)
     try:
         for i in os.listdir(data_dir):
-            if i.endswith('.part'): continue
+            if '.part' in i: continue
             if i.endswith('.ytdl'): continue
             if i.endswith('.temp'): continue
             if i.count('_') != media_type.count('_'): continue
             if i.startswith(media_type):
-                path = os.path.join(data_dir, i)
-                print(f'Serving {path}')
-                keepalive(data_dir)
-                print(f'Media for {url=} and {media_type=} found')
-                return path
+                return os.path.join(data_dir, i)
     except:
         return None
     return None
+
+
+def check_media(url: str, media_type: str):
+    print(f'Checking media for {url=} and {media_type=}')
+    path = _find_cached_media(url, media_type)
+    if path:
+        print(f'Serving {path}')
+        keepalive(get_data_dir(url))
+        print(f'Media for {url=} and {media_type=} found')
+    return path
 
 
 def get_meta(url: str, max_meta_age = None):
@@ -1328,7 +1869,8 @@ def get_video_info(meta: dict):
     info['width'] = meta.get('width')
     info['height'] = meta.get('height')
     info['url'] = meta.get('original_url')
-    info['default_quality'] = 'audio' if 'Music' in (meta.get('categories') or []) and audio_visualizer else get_good_quality(info['formats'])
+    info['cache_quality'] = get_good_quality(info['formats'])
+    info['default_quality'] = 'audio' if 'Music' in (meta.get('categories') or []) and audio_visualizer else info['cache_quality']
     info['autoplay'] = autoplay
     info['min_live_buffer'] = min_live_buffer
     info['always_transcode'] = always_transcode

--- a/src/app.py
+++ b/src/app.py
@@ -107,34 +107,26 @@ def raw():
 
 @app.route('/download')
 def download_media():
-    progress = None
-    uses_canonical_cache = False
     try:
         res = (request.args.get('quality') or '')
         start_time = request.args.get('start', 0, type=float)
         end_time = request.args.get('end', 0, type=float)
-        
+        is_trimmed = start_time > 0 or end_time > 0
+
         media_type = 'audio' if res == 'audio' else f'video-{res}'.removesuffix('-')
-        
-        if start_time > 0 or end_time > 0:
+
+        if is_trimmed:
             media_type += f'_{start_time:.1f}-{end_time:.1f}'
 
         url = get_url(request)
         if not url: return jsonify({"error": "URL parameter is required"}), 400
-        progress_id = request.args.get('progress_id')
-        if progress_id and not DownloadProgress.valid_id(progress_id):
-            return jsonify({"error": "Invalid progress ID"}), 400
-        is_full_video_cache = not progress_id and res != 'audio' and start_time <= 0 and end_time <= 0
-        cache_quality = normalize_cache_quality(res) if res != 'audio' else None
-        uses_canonical_cache = cache_quality is not None
-        if is_full_video_cache:
-            progress_id = cache_progress_id(res)
-        progress = DownloadProgress(url, progress_id)
 
-        if uses_canonical_cache:
+        cache_quality = normalize_cache_quality(res) if res != 'audio' else None
+        is_full_video_download = cache_quality is not None and not is_trimmed
+
+        if cache_quality is not None:
             cached_video = wait_for_video_cache(url, cache_quality)
-            if start_time <= 0 and end_time <= 0:
-                if progress: progress.ready(os.path.getsize(cached_video))
+            if is_full_video_download:
                 try:
                     video_title = get_meta(url, float('inf')).get('title')
                 except Exception as error:
@@ -143,15 +135,10 @@ def download_media():
                 download_name = f'{video_title}-{res}.mp4' if video_title else None
                 return send_file_partial(cached_video, download_name=download_name)
 
-        if not progress_id or not DownloadProgress.read(url, progress_id):
-            progress.start()
         video_title = get_meta(url).get('title')
-        return host_file(url, media_type, download_name=video_title, progress=progress)
+        return host_file(url, media_type, download_name=video_title)
 
     except Exception as e:
-        # The background cache worker owns canonical progress and reports its
-        # own failures. A waiting HTTP request must never overwrite that state.
-        if progress and not uses_canonical_cache: progress.error(e)
         return pprint_exc(e)
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -24,6 +24,14 @@ signal.signal(signal.SIGINT, signal_handler)
 signal.signal(signal.SIGTERM, signal_handler)
 
 
+def _cache_pending_response(status='preparing'):
+    return Response(status=202, headers={
+        'X-Cache-Status': status,
+        'Retry-After': '1',
+        'Cache-Control': 'no-store',
+    })
+
+
 @app.route('/')
 def index():
     print('Started serving root')
@@ -108,7 +116,7 @@ def raw():
 @app.route('/download')
 def download_media():
     try:
-        res = (request.args.get('quality') or '')
+        res = request.args.get('quality') or ''
         start_time = request.args.get('start', 0, type=float)
         end_time = request.args.get('end', 0, type=float)
         is_trimmed = start_time > 0 or end_time > 0
@@ -122,28 +130,19 @@ def download_media():
         if not url: return jsonify({"error": "URL parameter is required"}), 400
 
         cache_quality = normalize_cache_quality(res) if res != 'audio' else None
-        is_full_video_download = cache_quality is not None and not is_trimmed
 
         if cache_quality is not None:
             cache_state = ensure_video_cache(url, cache_quality) or DownloadProgress.initial_state()
             if cache_state.get('status') != 'ready':
-                response = Response(status=202)
-                response.headers['X-Cache-Status'] = cache_state.get('status') or 'preparing'
-                response.headers['Retry-After'] = '1'
-                response.headers['Cache-Control'] = 'no-store'
-                return response
+                return _cache_pending_response(cache_state.get('status') or 'preparing')
 
             # ensure_video_cache only reports ready after validating the MP4.
             # Avoid running FFprobe again for the immediately following response.
             cached_video = get_ready_cached_video(url, cache_quality, validate=False)
             if not cached_video:
-                response = Response(status=202)
-                response.headers['X-Cache-Status'] = 'preparing'
-                response.headers['Retry-After'] = '1'
-                response.headers['Cache-Control'] = 'no-store'
-                return response
+                return _cache_pending_response()
 
-            if is_full_video_download:
+            if not is_trimmed:
                 try:
                     video_title = get_meta(url, float('inf')).get('title')
                 except Exception as error:
@@ -209,11 +208,13 @@ def resp_direct():
         url = get_url(request)
         playback_source = request.args.get('playback') or 'auto'
 
-        if playback_source != 'stream':
-            if cached_video := get_ready_cached_video(url, res, validate=playback_source != 'local'):
-                response = send_file_partial(cached_video)
-                response.headers['X-Playback-Source'] = 'local'
-                return response
+        cached_video = None if playback_source == 'stream' else get_ready_cached_video(
+            url, res, validate=playback_source != 'local'
+        )
+        if cached_video:
+            response = send_file_partial(cached_video)
+            response.headers['X-Playback-Source'] = 'local'
+            return response
 
         # The browser uses this HEAD request only to choose between local and
         # streamed playback. Do not open an upstream media connection here.
@@ -235,10 +236,8 @@ def resp_direct():
         else:
             response = jsonify({"error": f"Cannot gather {media_type}"}), 404
 
-        try:
+        if isinstance(response, Response):
             response.headers['X-Playback-Source'] = 'stream'
-        except AttributeError:
-            pass
         return response
     except Exception as e:
         return pprint_exc(e)

--- a/src/app.py
+++ b/src/app.py
@@ -155,51 +155,6 @@ def download_media():
         return pprint_exc(e)
 
 
-@app.route('/download-progress')
-def download_progress():
-    url = get_url(request)
-    progress_id = request.args.get('progress_id')
-    if not url: return jsonify({"error": "URL parameter is required"}), 400
-    if not DownloadProgress.valid_id(progress_id): return jsonify({"error": "Invalid progress ID"}), 400
-
-    state = DownloadProgress.read(url, progress_id) or {
-        'status': 'preparing',
-        'percent': 0,
-        'downloaded_bytes': 0,
-        'total_bytes': 0,
-        'speed': 0,
-    }
-    response = jsonify(state)
-    response.headers['Cache-Control'] = 'no-store'
-    return response
-
-
-@app.route('/cache', methods=['POST'])
-def start_video_cache():
-    url = get_url(request)
-    quality = normalize_cache_quality(request.args.get('quality'))
-    if not url: return jsonify({"error": "URL parameter is required"}), 400
-    if not quality: return jsonify({"error": "A numeric or best video quality is required"}), 400
-
-    state = ensure_video_cache(url, quality)
-    response = jsonify(state)
-    response.headers['Cache-Control'] = 'no-store'
-    return response
-
-
-@app.route('/cache-progress')
-def video_cache_progress():
-    url = get_url(request)
-    quality = normalize_cache_quality(request.args.get('quality'))
-    if not url: return jsonify({"error": "URL parameter is required"}), 400
-    if not quality: return jsonify({"error": "A numeric or best video quality is required"}), 400
-
-    state = read_video_cache_progress(url, quality)
-    response = jsonify(state)
-    response.headers['Cache-Control'] = 'no-store'
-    return response
-
-
 @app.route('/cache-progress-stream')
 def video_cache_progress_stream():
     url = get_url(request)

--- a/src/app.py
+++ b/src/app.py
@@ -1,7 +1,9 @@
 import os
 import signal
 import sys
-from flask import Flask, render_template, request, jsonify, Response
+import json
+import time
+from flask import Flask, render_template, request, jsonify, Response, stream_with_context
 from io import BytesIO
 from starlette.middleware.wsgi import WSGIMiddleware
 
@@ -105,6 +107,8 @@ def raw():
 
 @app.route('/download')
 def download_media():
+    progress = None
+    uses_canonical_cache = False
     try:
         res = (request.args.get('quality') or '')
         start_time = request.args.get('start', 0, type=float)
@@ -116,11 +120,118 @@ def download_media():
             media_type += f'_{start_time:.1f}-{end_time:.1f}'
 
         url = get_url(request)
+        if not url: return jsonify({"error": "URL parameter is required"}), 400
+        progress_id = request.args.get('progress_id')
+        if progress_id and not DownloadProgress.valid_id(progress_id):
+            return jsonify({"error": "Invalid progress ID"}), 400
+        is_full_video_cache = not progress_id and res != 'audio' and start_time <= 0 and end_time <= 0
+        cache_quality = normalize_cache_quality(res) if res != 'audio' else None
+        uses_canonical_cache = cache_quality is not None
+        if is_full_video_cache:
+            progress_id = cache_progress_id(res)
+        progress = DownloadProgress(url, progress_id)
+
+        if uses_canonical_cache:
+            cached_video = wait_for_video_cache(url, cache_quality)
+            if start_time <= 0 and end_time <= 0:
+                if progress: progress.ready(os.path.getsize(cached_video))
+                try:
+                    video_title = get_meta(url, float('inf')).get('title')
+                except Exception as error:
+                    pprint_exc(error)
+                    video_title = None
+                download_name = f'{video_title}-{res}.mp4' if video_title else None
+                return send_file_partial(cached_video, download_name=download_name)
+
+        if not progress_id or not DownloadProgress.read(url, progress_id):
+            progress.start()
         video_title = get_meta(url).get('title')
-        return host_file(url, media_type, download_name=video_title)
+        return host_file(url, media_type, download_name=video_title, progress=progress)
 
     except Exception as e:
+        # The background cache worker owns canonical progress and reports its
+        # own failures. A waiting HTTP request must never overwrite that state.
+        if progress and not uses_canonical_cache: progress.error(e)
         return pprint_exc(e)
+
+
+@app.route('/download-progress')
+def download_progress():
+    url = get_url(request)
+    progress_id = request.args.get('progress_id')
+    if not url: return jsonify({"error": "URL parameter is required"}), 400
+    if not DownloadProgress.valid_id(progress_id): return jsonify({"error": "Invalid progress ID"}), 400
+
+    state = DownloadProgress.read(url, progress_id) or {
+        'status': 'preparing',
+        'percent': 0,
+        'downloaded_bytes': 0,
+        'total_bytes': 0,
+        'speed': 0,
+    }
+    response = jsonify(state)
+    response.headers['Cache-Control'] = 'no-store'
+    return response
+
+
+@app.route('/cache', methods=['POST'])
+def start_video_cache():
+    url = get_url(request)
+    quality = normalize_cache_quality(request.args.get('quality'))
+    if not url: return jsonify({"error": "URL parameter is required"}), 400
+    if not quality: return jsonify({"error": "A numeric or best video quality is required"}), 400
+
+    state = ensure_video_cache(url, quality)
+    response = jsonify(state)
+    response.headers['Cache-Control'] = 'no-store'
+    return response
+
+
+@app.route('/cache-progress')
+def video_cache_progress():
+    url = get_url(request)
+    quality = normalize_cache_quality(request.args.get('quality'))
+    if not url: return jsonify({"error": "URL parameter is required"}), 400
+    if not quality: return jsonify({"error": "A numeric or best video quality is required"}), 400
+
+    state = read_video_cache_progress(url, quality)
+    response = jsonify(state)
+    response.headers['Cache-Control'] = 'no-store'
+    return response
+
+
+@app.route('/cache-progress-stream')
+def video_cache_progress_stream():
+    url = get_url(request)
+    quality = normalize_cache_quality(request.args.get('quality'))
+    if not url: return jsonify({"error": "URL parameter is required"}), 400
+    if not quality: return jsonify({"error": "A numeric or best video quality is required"}), 400
+
+    def generate_events():
+        start_video_cache_if_new(url, quality)
+        previous_event = None
+        next_keepalive = time.monotonic() + 15
+        yield 'retry: 3000\n\n'
+
+        while True:
+            state = read_video_cache_progress(url, quality)
+            event = json.dumps(state, separators=(',', ':'))
+            if event != previous_event:
+                yield f'data: {event}\n\n'
+                previous_event = event
+                next_keepalive = time.monotonic() + 15
+            elif time.monotonic() >= next_keepalive:
+                yield ': keep-alive\n\n'
+                next_keepalive = time.monotonic() + 15
+
+            if state.get('status') == 'ready':
+                return
+            time.sleep(DownloadProgress.update_interval)
+
+    response = Response(stream_with_context(generate_events()), mimetype='text/event-stream')
+    response.headers['Cache-Control'] = 'no-cache, no-transform'
+    response.headers['X-Accel-Buffering'] = 'no'
+    return response
 
 
 @app.route('/low')
@@ -137,11 +248,39 @@ def resp_direct():
         res = request.args.get('quality') or ''
         media_type = f'direct-{res}'.removesuffix('-')
         url = get_url(request)
-        media = check_media(url, media_type)
+        playback_source = request.args.get('playback') or 'auto'
+
+        if playback_source != 'stream':
+            if cached_video := get_ready_cached_video(url, res, validate=playback_source != 'local'):
+                response = send_file_partial(cached_video)
+                response.headers['X-Playback-Source'] = 'local'
+                return response
+
+        # The browser uses this HEAD request only to choose between local and
+        # streamed playback. Do not open an upstream media connection here.
+        if request.method == 'HEAD':
+            response = Response(status=200)
+            response.headers['X-Playback-Source'] = 'stream'
+            response.headers['Cache-Control'] = 'no-store'
+            return response
+
+        media = check_media(url, media_type) or MediaDownloader(url, media_type).run()
         if media and media.endswith('.url'):
             with open(media, 'r') as f:
-                return stream_media_file(f.readline().rstrip('\n'), f.readline().rstrip('\n'), f.readline().rstrip('\n'))
-        return host_file(url, media_type)
+                src = f.readline().rstrip('\n')
+                headers = f.readline().rstrip('\n')
+                cookies = f.read().rstrip('\n')
+            response = stream_media_file(url, src, headers, cookies)
+        elif media:
+            response = send_file_partial(media)
+        else:
+            response = jsonify({"error": f"Cannot gather {media_type}"}), 404
+
+        try:
+            response.headers['X-Playback-Source'] = 'stream'
+        except AttributeError:
+            pass
+        return response
     except Exception as e:
         return pprint_exc(e)
 

--- a/src/app.py
+++ b/src/app.py
@@ -125,7 +125,24 @@ def download_media():
         is_full_video_download = cache_quality is not None and not is_trimmed
 
         if cache_quality is not None:
-            cached_video = wait_for_video_cache(url, cache_quality)
+            cache_state = ensure_video_cache(url, cache_quality) or DownloadProgress.initial_state()
+            if cache_state.get('status') != 'ready':
+                response = Response(status=202)
+                response.headers['X-Cache-Status'] = cache_state.get('status') or 'preparing'
+                response.headers['Retry-After'] = '1'
+                response.headers['Cache-Control'] = 'no-store'
+                return response
+
+            # ensure_video_cache only reports ready after validating the MP4.
+            # Avoid running FFprobe again for the immediately following response.
+            cached_video = get_ready_cached_video(url, cache_quality, validate=False)
+            if not cached_video:
+                response = Response(status=202)
+                response.headers['X-Cache-Status'] = 'preparing'
+                response.headers['Retry-After'] = '1'
+                response.headers['Cache-Control'] = 'no-store'
+                return response
+
             if is_full_video_download:
                 try:
                     video_title = get_meta(url, float('inf')).get('title')

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,7 @@
 dotenv
 Flask
 requests
-yt-dlp
+yt-dlp[default,curl-cffi]
 pillow
 psutil
 uvicorn

--- a/src/static/script.js
+++ b/src/static/script.js
@@ -104,14 +104,14 @@ function updateCacheProgress(data)
     const label = document.getElementById('download-progress-text');
     if (!container || !track || !fill || !label) return;
 
-    const percent = Math.max(0, Math.min(100, Number(data.percent) || 0));
+    const percent = data.status === 'encoding'
+        ? 100
+        : Math.max(0, Math.min(100, Number(data.percent) || 0));
     fill.style.width = `${percent}%`;
     track.setAttribute('aria-valuenow', `${Math.round(percent)}`);
 
     if (data.status === 'encoding')
     {
-        fill.style.width = '100%';
-        track.setAttribute('aria-valuenow', '100');
         label.textContent = 'Encoding video with FFMPEG';
         return;
     }
@@ -135,6 +135,31 @@ function triggerFileDownload(downloadUrl)
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
+}
+
+
+function prepareDownload(downloadUrl, quality)
+{
+    if (quality === 'audio')
+    {
+        return retryFetch(downloadUrl, {}, 100, undefined, true, true)
+            .then(() => triggerFileDownload(downloadUrl));
+    }
+
+    startCacheProgress(quality);
+    return retryFetch(downloadUrl, { cache: 'no-store' }, 0, undefined, false, true)
+        .then(response => {
+            if (response.status === 202)
+            {
+                pendingVideoDownload = { url: downloadUrl, quality: `${quality}` };
+                // The cache may have become ready between the HEAD response and
+                // this callback. Reopen SSE if it already closed on readiness.
+                startCacheProgress(quality);
+                return;
+            }
+            pendingVideoDownload = null;
+            triggerFileDownload(downloadUrl);
+        });
 }
 
 
@@ -165,10 +190,10 @@ function startCacheProgress(quality)
     const url = getUrlInfo();
     const progressUrl = `/cache-progress-stream?url=${url.encodedUrl}&quality=${encodeURIComponent(quality)}`;
     const eventSource = new EventSource(progressUrl);
-    activeCacheProgress = { quality: quality, eventSource: eventSource };
+    activeCacheProgress = { quality, eventSource };
 
     const handleState = data => {
-        if (!activeCacheProgress || activeCacheProgress.quality !== quality) return false;
+        if (!activeCacheProgress || activeCacheProgress.quality !== quality) return;
         if (data.status === 'ready')
         {
             const pendingDownload = pendingVideoDownload?.quality === quality
@@ -177,12 +202,11 @@ function startCacheProgress(quality)
             if (pendingDownload) pendingVideoDownload = null;
             stopCacheProgress(quality);
             if (pendingDownload) triggerFileDownload(pendingDownload.url);
-            return false;
+            return;
         }
         if (data.status === 'error' && pendingVideoDownload?.quality === quality)
             pendingVideoDownload = null;
         updateCacheProgress(data);
-        return true;
     };
 
     eventSource.onmessage = event => {
@@ -901,7 +925,8 @@ class DownloadButton extends videojs.getComponent('Button')
 
             const handleEvent = (event) => {
                 tryStopPropagation(event);
-                if (option.quality == 'trim') {
+                if (option.quality == 'trim')
+                {
                     if (this.startBtn.style.display === 'block')
                     {
                         this.startBtn.style.display = 'none';
@@ -915,63 +940,32 @@ class DownloadButton extends videojs.getComponent('Button')
                         this.endTime = null;
                         this.updateTimeLabels();
                     }
+                    return;
                 }
-                else
-                {
-                    if (this.downloadRequestPending) return;
-                    this.downloadRequestPending = true;
 
-                    var url = getUrlInfo();
-                    const currentQuality = url.quality || info.default_quality;
-                    var quality = option.quality;
-                    if (option.quality == 'current') quality = currentQuality;
+                if (this.downloadRequestPending) return;
+                this.downloadRequestPending = true;
 
-                    let downloadUrl = `/download?url=${url.encodedUrl}&quality=${quality}`;
-                    const isTrimmedDownload = this.startTime != null && this.endTime != null;
+                const url = getUrlInfo();
+                const currentQuality = url.quality || info.default_quality;
+                const quality = option.quality == 'current' ? currentQuality : option.quality;
+                let downloadUrl = `/download?url=${url.encodedUrl}&quality=${quality}`;
 
-                    if (isTrimmedDownload)
-                        downloadUrl += `&start=${this.startTime.toFixed(1)}&end=${this.endTime.toFixed(1)}`;
+                if (this.startTime != null && this.endTime != null)
+                    downloadUrl += `&start=${this.startTime.toFixed(1)}&end=${this.endTime.toFixed(1)}`;
 
-                    if (quality !== 'audio')
-                    {
-                        startCacheProgress(quality);
-                        retryFetch(downloadUrl, { cache: 'no-store' }, 0, undefined, false, true)
-                            .then(response => {
-                                if (response.status === 202)
-                                {
-                                    pendingVideoDownload = { url: downloadUrl, quality: `${quality}` };
-                                    // The cache may have become ready between the HEAD
-                                    // response and this callback. Reopen SSE if its prior
-                                    // ready event already closed the connection.
-                                    startCacheProgress(quality);
-                                    return;
-                                }
-                                pendingVideoDownload = null;
-                                triggerFileDownload(downloadUrl);
-                            })
-                            .catch(error => {
-                                console.error('Unable to prepare video download', error);
-                            })
-                            .finally(() => {
-                                this.downloadRequestPending = false;
-                            });
-                    }
-                    else
-                    {
-                        retryFetch(downloadUrl, {}, 100, undefined, true, true)
-                            .then(response => {
-                                triggerFileDownload(downloadUrl);
-                            })
-                            .catch(error => {
-                                console.error('Unable to prepare download', error);
-                            })
-                            .finally(() => {
-                                this.downloadRequestPending = false;
-                            });
-                    }
+                prepareDownload(downloadUrl, quality)
+                    .catch(error => {
+                        const message = quality === 'audio'
+                            ? 'Unable to prepare download'
+                            : 'Unable to prepare video download';
+                        console.error(message, error);
+                    })
+                    .finally(() => {
+                        this.downloadRequestPending = false;
+                    });
 
-                    this.handleCloseMenu(true);
-                }
+                this.handleCloseMenu(true);
             };
 
             button.addEventListener('click', handleEvent);

--- a/src/static/script.js
+++ b/src/static/script.js
@@ -14,6 +14,7 @@ let audioContext = null;
 let audioSource = null;
 let activeCacheProgress = null;
 let playbackSourcePreference = null;
+let pendingVideoDownload = null;
 
 
 
@@ -126,6 +127,17 @@ function updateCacheProgress(data)
 }
 
 
+function triggerFileDownload(downloadUrl)
+{
+    const link = document.createElement('a');
+    link.href = downloadUrl;
+    link.download = 'file';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+}
+
+
 function stopCacheProgress(quality = null)
 {
     if (!activeCacheProgress || (quality !== null && activeCacheProgress.quality !== quality)) return;
@@ -159,9 +171,16 @@ function startCacheProgress(quality)
         if (!activeCacheProgress || activeCacheProgress.quality !== quality) return false;
         if (data.status === 'ready')
         {
+            const pendingDownload = pendingVideoDownload?.quality === quality
+                ? pendingVideoDownload
+                : null;
+            if (pendingDownload) pendingVideoDownload = null;
             stopCacheProgress(quality);
+            if (pendingDownload) triggerFileDownload(pendingDownload.url);
             return false;
         }
+        if (data.status === 'error' && pendingVideoDownload?.quality === quality)
+            pendingVideoDownload = null;
         updateCacheProgress(data);
         return true;
     };
@@ -907,34 +926,41 @@ class DownloadButton extends videojs.getComponent('Button')
                     var quality = option.quality;
                     if (option.quality == 'current') quality = currentQuality;
 
-                    const link = document.createElement('a');
                     let downloadUrl = `/download?url=${url.encodedUrl}&quality=${quality}`;
                     const isTrimmedDownload = this.startTime != null && this.endTime != null;
 
                     if (isTrimmedDownload)
                         downloadUrl += `&start=${this.startTime.toFixed(1)}&end=${this.endTime.toFixed(1)}`;
 
-                    link.href = downloadUrl;
-                    link.download = 'file';
-
                     if (quality !== 'audio')
                     {
                         startCacheProgress(quality);
-                        // Start the real browser download while this click still has
-                        // user activation. The request can wait for an active cache
-                        // job, so a separate HEAD preparation request is unnecessary.
-                        document.body.appendChild(link);
-                        link.click();
-                        document.body.removeChild(link);
-                        this.downloadRequestPending = false;
+                        retryFetch(downloadUrl, { cache: 'no-store' }, 0, undefined, false, true)
+                            .then(response => {
+                                if (response.status === 202)
+                                {
+                                    pendingVideoDownload = { url: downloadUrl, quality: `${quality}` };
+                                    // The cache may have become ready between the HEAD
+                                    // response and this callback. Reopen SSE if its prior
+                                    // ready event already closed the connection.
+                                    startCacheProgress(quality);
+                                    return;
+                                }
+                                pendingVideoDownload = null;
+                                triggerFileDownload(downloadUrl);
+                            })
+                            .catch(error => {
+                                console.error('Unable to prepare video download', error);
+                            })
+                            .finally(() => {
+                                this.downloadRequestPending = false;
+                            });
                     }
                     else
                     {
                         retryFetch(downloadUrl, {}, 100, undefined, true, true)
                             .then(response => {
-                                document.body.appendChild(link);
-                                link.click();
-                                document.body.removeChild(link);
+                                triggerFileDownload(downloadUrl);
                             })
                             .catch(error => {
                                 console.error('Unable to prepare download', error);

--- a/src/static/script.js
+++ b/src/static/script.js
@@ -12,6 +12,8 @@ let usesHls = false;
 let ongoingRequest = null;
 let audioContext = null;
 let audioSource = null;
+let activeCacheProgress = null;
+let playbackSourcePreference = null;
 
 
 
@@ -90,6 +92,96 @@ function tryStopPropagation(event)
     }
     catch (error) {}
     player.el_.focus();
+}
+
+
+function updateCacheProgress(data)
+{
+    const container = document.getElementById('download-progress-container');
+    const track = document.getElementById('download-progress-track');
+    const fill = document.getElementById('download-progress-fill');
+    const label = document.getElementById('download-progress-text');
+    if (!container || !track || !fill || !label) return;
+
+    const percent = Math.max(0, Math.min(100, Number(data.percent) || 0));
+    fill.style.width = `${percent}%`;
+    track.setAttribute('aria-valuenow', `${Math.round(percent)}`);
+
+    if (data.status === 'encoding')
+    {
+        fill.style.width = '100%';
+        track.setAttribute('aria-valuenow', '100');
+        label.textContent = 'Encoding video with FFMPEG';
+        return;
+    }
+
+    if (data.status === 'error')
+    {
+        label.textContent = 'Unable to cache video';
+        return;
+    }
+
+    const bytesToMb = value => (Math.max(0, Number(value) || 0) / 1000000).toFixed(2);
+    label.textContent = `${bytesToMb(data.downloaded_bytes)}MB/${bytesToMb(data.total_bytes)}MB - (${bytesToMb(data.speed)}MB/s)`;
+}
+
+
+function stopCacheProgress(quality = null)
+{
+    if (!activeCacheProgress || (quality !== null && activeCacheProgress.quality !== quality)) return;
+    activeCacheProgress.eventSource.close();
+    activeCacheProgress = null;
+
+    const container = document.getElementById('download-progress-container');
+    if (container) container.hidden = true;
+    document.body.classList.remove('download-progress-visible');
+}
+
+
+function startCacheProgress(quality)
+{
+    quality = `${quality || ''}`;
+    if (quality !== 'best' && !/^\d{1,4}$/.test(quality)) return;
+    if (activeCacheProgress?.quality === quality) return;
+    if (activeCacheProgress) stopCacheProgress();
+
+    const container = document.getElementById('download-progress-container');
+    if (container) container.hidden = false;
+    document.body.classList.add('download-progress-visible');
+    updateCacheProgress({ status: 'preparing', percent: 0, downloaded_bytes: 0, total_bytes: 0, speed: 0 });
+
+    const url = getUrlInfo();
+    const progressUrl = `/cache-progress-stream?url=${url.encodedUrl}&quality=${encodeURIComponent(quality)}`;
+    const eventSource = new EventSource(progressUrl);
+    activeCacheProgress = { quality: quality, eventSource: eventSource };
+
+    const handleState = data => {
+        if (!activeCacheProgress || activeCacheProgress.quality !== quality) return false;
+        if (data.status === 'ready')
+        {
+            stopCacheProgress(quality);
+            return false;
+        }
+        updateCacheProgress(data);
+        return true;
+    };
+
+    eventSource.onmessage = event => {
+        if (!activeCacheProgress || activeCacheProgress.quality !== quality) return;
+        try
+        {
+            handleState(JSON.parse(event.data));
+        }
+        catch (error)
+        {
+            console.error('Unable to read cache progress event', error);
+        }
+    };
+
+    eventSource.onerror = error => {
+        if (!activeCacheProgress || activeCacheProgress.quality !== quality) return;
+        console.error('Cache progress stream disconnected; waiting for reconnect', error);
+    };
 }
 
 
@@ -340,7 +432,7 @@ function loadChapters()
 }
 
 
-function getVideoSource()
+function getVideoSource(playbackSource = playbackSourcePreference)
 {
     var url = getUrlInfo();
     console.log(`Video quality: ${url.quality}`);
@@ -352,6 +444,11 @@ function getVideoSource()
     {
         downloadUrl = `/hls?url=${url.encodedUrl}&quality=${url.quality}`;
         videoType = 'application/x-mpegURL';
+    }
+    else if (playbackSource === 'local' || playbackSource === 'stream')
+    {
+        downloadUrl += `&playback=${playbackSource}`;
+        if (playbackSource === 'local') videoType = 'video/mp4';
     }
 
     console.log(`Video source: src=${downloadUrl} type=${videoType}`);
@@ -440,9 +537,12 @@ function setVideoQuality(height = null, button = null)
         });
     }
     history.replaceState(null, '', `${window.location.pathname}?${url.urlParams.toString()}`);
+    if (parseFloat(info.duration) > 0)
+        startCacheProgress(height === 'audio' ? info.cache_quality : height);
 
     if (usesHls)
     {
+        playbackSourcePreference = 'stream';
         console.log('Fetching HLS...');
         retryFetch(getVideoSource()[0])
             .then(response => response.text())
@@ -471,9 +571,11 @@ function setVideoQuality(height = null, button = null)
     }
     else
     {
+        playbackSourcePreference = null;
         console.log('Fetching Direct...');
-        retryFetch(getVideoSource()[0], 2, undefined, undefined, undefined, true)
+        retryFetch(getVideoSource(null)[0], { cache: 'no-store' }, undefined, undefined, undefined, true)
             .then(response => {
+                playbackSourcePreference = response.headers.get('X-Playback-Source') === 'local' ? 'local' : 'stream';
                 applyVideoQuality();
                 buttons.forEach(btn => btn.classList.remove('vjs-menu-option-selected'));
                 button?.classList?.add('vjs-menu-option-selected');
@@ -797,32 +899,55 @@ class DownloadButton extends videojs.getComponent('Button')
                 }
                 else
                 {
+                    if (this.downloadRequestPending) return;
+                    this.downloadRequestPending = true;
+
                     var url = getUrlInfo();
                     const currentQuality = url.quality || info.default_quality;
                     var quality = option.quality;
                     if (option.quality == 'current') quality = currentQuality;
 
                     const link = document.createElement('a');
-                    link.href = `/download?url=${url.encodedUrl}&quality=${quality}`;
+                    let downloadUrl = `/download?url=${url.encodedUrl}&quality=${quality}`;
+                    const isTrimmedDownload = this.startTime != null && this.endTime != null;
 
-                    if (this.startTime != null && this.endTime != null)
-                        link.href += `&start=${this.startTime.toFixed(1)}&end=${this.endTime.toFixed(1)}`;
+                    if (isTrimmedDownload)
+                        downloadUrl += `&start=${this.startTime.toFixed(1)}&end=${this.endTime.toFixed(1)}`;
 
+                    link.href = downloadUrl;
                     link.download = 'file';
 
-                    retryFetch(link.href, {}, 100, undefined, true, true).then(response => {
+                    if (quality !== 'audio')
+                    {
+                        startCacheProgress(quality);
+                        // Start the real browser download while this click still has
+                        // user activation. The request can wait for an active cache
+                        // job, so a separate HEAD preparation request is unnecessary.
                         document.body.appendChild(link);
                         link.click();
                         document.body.removeChild(link);
-                    })
+                        this.downloadRequestPending = false;
+                    }
+                    else
+                    {
+                        retryFetch(downloadUrl, {}, 100, undefined, true, true)
+                            .then(response => {
+                                document.body.appendChild(link);
+                                link.click();
+                                document.body.removeChild(link);
+                            })
+                            .catch(error => {
+                                console.error('Unable to prepare download', error);
+                            })
+                            .finally(() => {
+                                this.downloadRequestPending = false;
+                            });
+                    }
 
                     this.handleCloseMenu(true);
-                    retryFetch(link.href)
-                        .then(response => response.text())
                 }
             };
 
-            button.addEventListener('touchend', handleEvent);
             button.addEventListener('click', handleEvent);
 
             menu.appendChild(button);

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -158,6 +158,71 @@ body
 }
 
 
+#player-layout
+{
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.media-progress-container
+{
+    width: min(600px, 60vw);
+    max-width: 90vw;
+    margin-top: 14px;
+    color: #eee;
+    text-align: center;
+    font-size: 14px;
+}
+
+.media-progress-container[hidden]
+{
+    display: none;
+}
+
+.media-progress-track
+{
+    width: 100%;
+    height: 9px;
+    overflow: hidden;
+    border: 1px solid #777;
+    border-radius: 3px;
+    background-color: #333;
+}
+
+.media-progress-fill
+{
+    width: 0;
+    height: 100%;
+    background-color: #eee;
+    transition: width 0.15s linear;
+}
+
+.media-progress-text
+{
+    margin-top: 7px;
+    text-shadow: 0 1px 2px #000;
+}
+
+body.iframe-player-page #player-layout
+{
+    width: 100vw;
+    height: 100vh;
+}
+
+body.iframe-player-page.download-progress-visible #videoPlayer
+{
+    height: calc(100vh - 54px) !important;
+    min-height: calc(100vh - 54px) !important;
+}
+
+body.iframe-player-page .media-progress-container
+{
+    flex: 0 0 40px;
+    margin-top: 8px;
+}
+
+
 #videoPlayer:not(.vjs-fullscreen):not(.fit-contain) video
 {
     object-fit: cover !important;

--- a/src/templates/_download_progress.html
+++ b/src/templates/_download_progress.html
@@ -1,0 +1,6 @@
+<div id="download-progress-container" class="media-progress-container" hidden aria-live="polite">
+    <div id="download-progress-track" class="media-progress-track" role="progressbar" aria-label="Video cache download progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+        <div id="download-progress-fill" class="media-progress-fill"></div>
+    </div>
+    <div id="download-progress-text" class="media-progress-text">0.00MB/0.00MB - (0.00MB/s)</div>
+</div>

--- a/src/templates/iframe.html
+++ b/src/templates/iframe.html
@@ -29,15 +29,23 @@
         <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" type="text/css" />
         <link rel="stylesheet" href="{{ url_for('static', filename='videojs.css') }}" type="text/css" />
     </head>
-    <body>
+    <body class="iframe-player-page">
         
-        <div class="container" id="video">
-            <video id="videoPlayer" class="video-js vjs-default-skin vjs-big-play-centered vjs-theme-custom" controls preload="auto" width="100%" height="100%">
-                <p class="vjs-no-js">
-                    To view this video please enable JavaScript, and consider upgrading to a
-                    web browser that <a href="https://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a>
-                </p>
-            </video>
+        <div id="player-layout">
+            <div class="container" id="video">
+                <video id="videoPlayer" class="video-js vjs-default-skin vjs-big-play-centered vjs-theme-custom" controls preload="auto" width="100%" height="100%">
+                    <p class="vjs-no-js">
+                        To view this video please enable JavaScript, and consider upgrading to a
+                        web browser that <a href="https://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a>
+                    </p>
+                </video>
+            </div>
+            <div id="download-progress-container" class="media-progress-container" hidden aria-live="polite">
+                <div id="download-progress-track" class="media-progress-track" role="progressbar" aria-label="Video cache download progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                    <div id="download-progress-fill" class="media-progress-fill"></div>
+                </div>
+                <div id="download-progress-text" class="media-progress-text">0.00MB/0.00MB - (0.00MB/s)</div>
+            </div>
         </div>
 
         <!-- VideoJS Script -->

--- a/src/templates/iframe.html
+++ b/src/templates/iframe.html
@@ -40,12 +40,7 @@
                     </p>
                 </video>
             </div>
-            <div id="download-progress-container" class="media-progress-container" hidden aria-live="polite">
-                <div id="download-progress-track" class="media-progress-track" role="progressbar" aria-label="Video cache download progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-                    <div id="download-progress-fill" class="media-progress-fill"></div>
-                </div>
-                <div id="download-progress-text" class="media-progress-text">0.00MB/0.00MB - (0.00MB/s)</div>
-            </div>
+            {% include '_download_progress.html' %}
         </div>
 
         <!-- VideoJS Script -->

--- a/src/templates/watch.html
+++ b/src/templates/watch.html
@@ -53,13 +53,21 @@
             </a>
         </div>
         
-        <div class="container" id="video">
-            <video id="videoPlayer" class="video-js vjs-default-skin vjs-big-play-centered vjs-theme-custom" controls preload="auto" width="100%" height="100%">
-                <p class="vjs-no-js">
-                    To view this video please enable JavaScript, and consider upgrading to a
-                    web browser that <a href="https://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a>
-                </p>
-            </video>
+        <div id="player-layout">
+            <div class="container" id="video">
+                <video id="videoPlayer" class="video-js vjs-default-skin vjs-big-play-centered vjs-theme-custom" controls preload="auto" width="100%" height="100%">
+                    <p class="vjs-no-js">
+                        To view this video please enable JavaScript, and consider upgrading to a
+                        web browser that <a href="https://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a>
+                    </p>
+                </video>
+            </div>
+            <div id="download-progress-container" class="media-progress-container" hidden aria-live="polite">
+                <div id="download-progress-track" class="media-progress-track" role="progressbar" aria-label="Video cache download progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                    <div id="download-progress-fill" class="media-progress-fill"></div>
+                </div>
+                <div id="download-progress-text" class="media-progress-text">0.00MB/0.00MB - (0.00MB/s)</div>
+            </div>
         </div>
         
         <div id="expandable-menu-container">

--- a/src/templates/watch.html
+++ b/src/templates/watch.html
@@ -62,12 +62,7 @@
                     </p>
                 </video>
             </div>
-            <div id="download-progress-container" class="media-progress-container" hidden aria-live="polite">
-                <div id="download-progress-track" class="media-progress-track" role="progressbar" aria-label="Video cache download progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-                    <div id="download-progress-fill" class="media-progress-fill"></div>
-                </div>
-                <div id="download-progress-text" class="media-progress-text">0.00MB/0.00MB - (0.00MB/s)</div>
-            </div>
+            {% include '_download_progress.html' %}
         </div>
         
         <div id="expandable-menu-container">

--- a/src/version.py
+++ b/src/version.py
@@ -18,4 +18,4 @@ for tag in repo.tags or []:
         version_string = str(tag)
 
 with open('version.txt', 'w') as f:
-    f.write(version_string)
+    f.write("fengax:0.0.8")

--- a/src/version.py
+++ b/src/version.py
@@ -18,4 +18,4 @@ for tag in repo.tags or []:
         version_string = str(tag)
 
 with open('version.txt', 'w') as f:
-    f.write("fengax:0.0.8")
+    f.write(version_string)

--- a/tests/test_cache_lock.py
+++ b/tests/test_cache_lock.py
@@ -1,0 +1,81 @@
+import os
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+
+SOURCE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
+if SOURCE_DIR not in sys.path:
+    sys.path.insert(0, SOURCE_DIR)
+
+import addons
+
+
+class FileCachingLockTests(unittest.TestCase):
+    def test_concurrent_requests_only_generate_media_once(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            media_path = os.path.join(data_dir, 'video-720.mp4')
+            barrier = threading.Barrier(2)
+            work_count = 0
+            results = []
+            errors = []
+            state_lock = threading.Lock()
+
+            def check_cached_media(**_kwargs):
+                return media_path if os.path.exists(media_path) else None
+
+            def worker():
+                nonlocal work_count
+                try:
+                    lock = addons.FileCachingLock('https://example.com/video', 'video-720')
+                    lock.max_wait_attempts = 100
+                    lock.retry_interval_seconds = 0.005
+                    barrier.wait()
+                    with lock as cached_media:
+                        if cached_media:
+                            results.append(cached_media)
+                            return
+                        with state_lock:
+                            work_count += 1
+                        time.sleep(0.05)
+                        with open(media_path, 'wb') as media_file:
+                            media_file.write(b'complete video')
+                        results.append(media_path)
+                except Exception as error:
+                    errors.append(error)
+
+            with (
+                patch.object(addons, 'get_data_dir', return_value=data_dir),
+                patch.object(addons, 'check_media', side_effect=check_cached_media),
+                patch.object(addons, 'keepalive'),
+            ):
+                threads = [threading.Thread(target=worker) for _ in range(2)]
+                for thread in threads:
+                    thread.start()
+                for thread in threads:
+                    thread.join()
+
+            self.assertEqual(errors, [])
+            self.assertEqual(work_count, 1)
+            self.assertEqual(results, [media_path, media_path])
+            self.assertFalse(os.path.exists(os.path.join(data_dir, 'video-720.temp')))
+
+    def test_lock_is_released_when_cache_check_fails(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            with (
+                patch.object(addons, 'get_data_dir', return_value=data_dir),
+                patch.object(addons, 'check_media', side_effect=RuntimeError('cache failure')),
+                patch.object(addons, 'keepalive'),
+            ):
+                lock = addons.FileCachingLock('https://example.com/video', 'video-720')
+                with self.assertRaisesRegex(RuntimeError, 'cache failure'):
+                    lock.__enter__()
+
+            self.assertFalse(os.path.exists(lock.lock_path))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_cache_lock.py
+++ b/tests/test_cache_lock.py
@@ -14,6 +14,46 @@ if SOURCE_DIR not in sys.path:
 import addons
 
 
+class CacheLockStoreTests(unittest.TestCase):
+    def test_job_lock_check_and_acquisition_is_atomic(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            barrier = threading.Barrier(2)
+            acquisitions = []
+
+            def acquire():
+                store = addons.CacheLockStore('https://example.com/video', 'video-720')
+                barrier.wait()
+                acquisitions.append(store.try_acquire_job_lock())
+
+            with patch.object(addons, 'get_data_dir', return_value=data_dir):
+                threads = [threading.Thread(target=acquire) for _ in range(2)]
+                for thread in threads:
+                    thread.start()
+                for thread in threads:
+                    thread.join()
+
+                store = addons.CacheLockStore('https://example.com/video', 'video-720')
+                self.assertEqual(sorted(acquisitions), [False, True])
+                self.assertTrue(store.job_lock_exists())
+                self.assertTrue(store.release_job_lock())
+                self.assertFalse(store.job_lock_exists())
+
+    def test_active_media_lock_prevents_stale_job_lock_removal(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            with patch.object(addons, 'get_data_dir', return_value=data_dir):
+                store = addons.CacheLockStore('https://example.com/video', 'video-720')
+                self.assertTrue(store.try_acquire_job_lock())
+                os.utime(store.job_lock_path, (0, 0))
+                self.assertTrue(store.try_acquire_media_lock())
+
+                self.assertFalse(store.remove_stale_job_lock(max_age=0))
+                self.assertTrue(store.job_lock_exists())
+
+                store.release_media_lock()
+                self.assertTrue(store.remove_stale_job_lock(max_age=0))
+                self.assertFalse(store.job_lock_exists())
+
+
 class FileCachingLockTests(unittest.TestCase):
     def test_concurrent_requests_only_generate_media_once(self):
         with tempfile.TemporaryDirectory() as data_dir:

--- a/tests/test_cache_progress.py
+++ b/tests/test_cache_progress.py
@@ -29,6 +29,42 @@ class DeferredThread:
         self.started = True
 
 
+class CacheProgressStoreTests(unittest.TestCase):
+    def test_progress_state_is_written_with_atomic_replace(self):
+        state = {
+            'status': 'downloading',
+            'percent': 25,
+            'downloaded_bytes': 25,
+            'total_bytes': 100,
+            'speed': 5,
+        }
+
+        with tempfile.TemporaryDirectory() as data_dir:
+            with (
+                patch.object(addons, 'get_data_dir', return_value=data_dir),
+                patch.object(addons.os, 'replace', wraps=os.replace) as replace,
+            ):
+                store = addons.CacheProgressStore('https://example.com/video', 'cache-720')
+                store.write(state)
+
+                self.assertEqual(store.read(), state)
+                replace.assert_called_once()
+                temp_path, destination = replace.call_args.args
+                self.assertEqual(destination, store.path)
+                self.assertFalse(os.path.exists(temp_path))
+
+    def test_invalid_progress_id_is_not_read_or_written(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            with patch.object(addons, 'get_data_dir', return_value=data_dir):
+                store = addons.CacheProgressStore(
+                    'https://example.com/video', '../../unsafe'
+                )
+                store.write({'status': 'ready'})
+
+                self.assertIsNone(store.read())
+                self.assertEqual(os.listdir(data_dir), [])
+
+
 class CacheProgressTests(unittest.TestCase):
     def setUp(self):
         DeferredThread.instances = []
@@ -106,9 +142,9 @@ class CacheProgressTests(unittest.TestCase):
                     'status': 'started',
                     'postprocessor': 'FixupM3u8',
                 })
-                state = addons.DownloadProgress.read(
+                state = addons.CacheProgressStore(
                     'https://example.com/video', 'cache-720'
-                )
+                ).read()
 
         self.assertEqual(state['status'], 'downloading')
         self.assertEqual(state['percent'], 100)
@@ -132,9 +168,9 @@ class CacheProgressTests(unittest.TestCase):
                     'total_bytes': 20_000_000,
                     'speed': 2_000_000,
                 })
-                observed_states.append(addons.DownloadProgress.read(
+                observed_states.append(addons.CacheProgressStore(
                     downloader.url, addons.CACHE_AUDIO_PROGRESS_ID
-                ))
+                ).read())
                 with open(os.path.join(data_dir, 'audio.mp3'), 'wb') as audio_file:
                     audio_file.write(b'complete audio')
 
@@ -143,9 +179,9 @@ class CacheProgressTests(unittest.TestCase):
                 patch.object(addons.YTDLP, 'download', side_effect=download_audio),
             ):
                 downloader.audio()
-                final_state = addons.DownloadProgress.read(
+                final_state = addons.CacheProgressStore(
                     downloader.url, addons.CACHE_AUDIO_PROGRESS_ID
-                )
+                ).read()
 
         self.assertEqual(observed_states[0]['status'], 'downloading')
         self.assertEqual(observed_states[0]['percent'], 25)

--- a/tests/test_cache_progress.py
+++ b/tests/test_cache_progress.py
@@ -266,28 +266,16 @@ class CacheProgressEndpointTests(unittest.TestCase):
         app_module.app.config['TESTING'] = True
         self.client = app_module.app.test_client()
 
-    def test_cache_progress_endpoint_returns_persistent_state(self):
-        state = {
-            'status': 'downloading',
-            'percent': 50,
-            'downloaded_bytes': 50,
-            'total_bytes': 100,
-            'speed': 10,
-        }
-        with patch.object(app_module, 'read_video_cache_progress', return_value=state):
-            response = self.client.get(
-                '/cache-progress?url=https%3A%2F%2Fexample.com%2Fvideo&quality=720'
-            )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.get_json(), state)
-        self.assertEqual(response.headers.get('Cache-Control'), 'no-store')
-
-    def test_cache_start_rejects_unsafe_quality(self):
-        response = self.client.post(
-            '/cache?url=https%3A%2F%2Fexample.com%2Fvideo&quality=..%2F..%2Fvideo'
+    def test_removed_legacy_cache_endpoints_return_not_found(self):
+        requests = (
+            ('GET', '/download-progress'),
+            ('POST', '/cache'),
+            ('GET', '/cache-progress'),
         )
-        self.assertEqual(response.status_code, 400)
+        for method, path in requests:
+            with self.subTest(path=path):
+                response = self.client.open(path, method=method)
+                self.assertEqual(response.status_code, 404)
 
     def test_sse_starts_cache_once_and_streams_changed_states_until_ready(self):
         downloading = {

--- a/tests/test_cache_progress.py
+++ b/tests/test_cache_progress.py
@@ -2,6 +2,7 @@ import os
 import json
 import sys
 import tempfile
+import threading
 import unittest
 from unittest.mock import patch
 
@@ -224,41 +225,34 @@ class CacheProgressTests(unittest.TestCase):
         self.assertEqual(state['downloaded_bytes'], len(b'ready video'))
         self.assertEqual(state['total_bytes'], len(b'ready video'))
 
-    def test_download_waiter_uses_existing_canonical_cache_job(self):
+    def test_simultaneous_cache_requests_start_one_canonical_job(self):
         with tempfile.TemporaryDirectory() as data_dir:
-            video_path = os.path.join(data_dir, 'video-720.mp4')
-            progress_state = {
-                'status': 'downloading',
-                'percent': 50,
-                'downloaded_bytes': 50,
-                'total_bytes': 100,
-                'speed': 10,
-            }
+            barrier = threading.Barrier(2)
+            results = []
+            errors = []
 
-            def finish_cache(_seconds):
-                with open(video_path, 'wb') as video_file:
-                    video_file.write(b'ready video')
+            def request_cache():
+                try:
+                    barrier.wait()
+                    results.append(addons.ensure_video_cache('https://example.com/video', '720'))
+                except Exception as error:
+                    errors.append(error)
 
             with (
                 patch.object(addons, 'get_data_dir', return_value=data_dir),
-                patch.object(addons, 'ensure_video_cache', return_value=progress_state) as ensure_video_cache,
-                patch.object(
-                    addons,
-                    'get_ready_cached_video',
-                    side_effect=[None, video_path],
-                ),
-                patch.object(addons, 'read_video_cache_progress', return_value=progress_state),
-                patch.object(addons.time, 'sleep', side_effect=finish_cache),
+                patch.object(addons, 'get_ready_cached_video', return_value=None),
+                patch.object(addons, 'Thread', DeferredThread),
             ):
-                result = addons.wait_for_video_cache(
-                    'https://example.com/video',
-                    '720',
-                    max_attempts=2,
-                    retry_interval=0,
-                )
+                requests = [threading.Thread(target=request_cache) for _ in range(2)]
+                for request in requests:
+                    request.start()
+                for request in requests:
+                    request.join()
 
-        ensure_video_cache.assert_called_once_with('https://example.com/video', '720')
-        self.assertEqual(result, video_path)
+        self.assertEqual(errors, [])
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all(state['status'] == 'preparing' for state in results))
+        self.assertEqual(len(DeferredThread.instances), 1)
 
 
 class CacheProgressEndpointTests(unittest.TestCase):

--- a/tests/test_cache_progress.py
+++ b/tests/test_cache_progress.py
@@ -1,0 +1,341 @@
+import os
+import json
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+SOURCE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
+if SOURCE_DIR not in sys.path:
+    sys.path.insert(0, SOURCE_DIR)
+
+import addons
+import app as app_module
+
+
+class DeferredThread:
+    instances = []
+
+    def __init__(self, target, args=(), daemon=None):
+        self.target = target
+        self.args = args
+        self.daemon = daemon
+        self.started = False
+        self.instances.append(self)
+
+    def start(self):
+        self.started = True
+
+
+class CacheProgressTests(unittest.TestCase):
+    def setUp(self):
+        DeferredThread.instances = []
+
+    def test_cache_quality_is_restricted_to_numeric_or_best(self):
+        self.assertEqual(addons.normalize_cache_quality('720'), '720')
+        self.assertEqual(addons.normalize_cache_quality('best'), 'best')
+        self.assertIsNone(addons.normalize_cache_quality('audio'))
+        self.assertIsNone(addons.normalize_cache_quality('../../video'))
+
+    def test_cache_progress_survives_a_new_reader(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            with (
+                patch.object(addons, 'get_data_dir', return_value=data_dir),
+                patch.object(addons, 'get_ready_cached_video', return_value=None),
+            ):
+                progress = addons.DownloadProgress('https://example.com/video', 'cache-720')
+                progress.download({
+                    'status': 'downloading',
+                    'downloaded_bytes': 25_000_000,
+                    'total_bytes': 100_000_000,
+                    'speed': 5_000_000,
+                })
+
+                state = addons.read_video_cache_progress('https://example.com/video', '720')
+
+        self.assertEqual(state['status'], 'downloading')
+        self.assertEqual(state['percent'], 25)
+        self.assertEqual(state['downloaded_bytes'], 25_000_000)
+        self.assertEqual(state['total_bytes'], 100_000_000)
+        self.assertEqual(state['speed'], 5_000_000)
+
+    def test_cache_progress_aggregates_concurrent_video_and_audio_downloads(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            with (
+                patch.object(addons, 'get_data_dir', return_value=data_dir),
+                patch.object(addons, 'get_ready_cached_video', return_value=None),
+            ):
+                video = addons.DownloadProgress('https://example.com/video', 'cache-720')
+                video.download({
+                    'status': 'downloading',
+                    'downloaded_bytes': 80_000_000,
+                    'total_bytes': 100_000_000,
+                    'speed': 5_000_000,
+                })
+                audio = addons.DownloadProgress(
+                    'https://example.com/video', addons.CACHE_AUDIO_PROGRESS_ID
+                )
+                audio.download({
+                    'status': 'downloading',
+                    'downloaded_bytes': 10_000_000,
+                    'total_bytes': 20_000_000,
+                    'speed': 2_000_000,
+                })
+
+                state = addons.read_video_cache_progress('https://example.com/video', '720')
+
+        self.assertEqual(state['status'], 'downloading')
+        self.assertEqual(state['percent'], 75)
+        self.assertEqual(state['downloaded_bytes'], 90_000_000)
+        self.assertEqual(state['total_bytes'], 120_000_000)
+        self.assertEqual(state['speed'], 7_000_000)
+
+    def test_hls_fixup_does_not_mark_cache_as_encoding(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            with patch.object(addons, 'get_data_dir', return_value=data_dir):
+                progress = addons.DownloadProgress('https://example.com/video', 'cache-720')
+                progress.download({
+                    'status': 'finished',
+                    'downloaded_bytes': 100_000_000,
+                    'total_bytes': 100_000_000,
+                })
+                progress.handle_ytdlp_event({
+                    'type': 'postprocessor',
+                    'status': 'started',
+                    'postprocessor': 'FixupM3u8',
+                })
+                state = addons.DownloadProgress.read(
+                    'https://example.com/video', 'cache-720'
+                )
+
+        self.assertEqual(state['status'], 'downloading')
+        self.assertEqual(state['percent'], 100)
+
+    def test_audio_download_publishes_shared_cache_progress_until_ready(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            downloader = addons.MediaDownloader.__new__(addons.MediaDownloader)
+            downloader.url = 'https://example.com/video'
+            downloader.data_dir = data_dir
+            downloader.media_type = 'audio'
+            downloader.progress = None
+            downloader.meta = {}
+            downloader.ydl_opts = {}
+            observed_states = []
+
+            def download_audio(_url, _opts, callback):
+                callback({
+                    'type': 'download',
+                    'status': 'downloading',
+                    'downloaded_bytes': 5_000_000,
+                    'total_bytes': 20_000_000,
+                    'speed': 2_000_000,
+                })
+                observed_states.append(addons.DownloadProgress.read(
+                    downloader.url, addons.CACHE_AUDIO_PROGRESS_ID
+                ))
+                with open(os.path.join(data_dir, 'audio.mp3'), 'wb') as audio_file:
+                    audio_file.write(b'complete audio')
+
+            with (
+                patch.object(addons, 'get_data_dir', return_value=data_dir),
+                patch.object(addons.YTDLP, 'download', side_effect=download_audio),
+            ):
+                downloader.audio()
+                final_state = addons.DownloadProgress.read(
+                    downloader.url, addons.CACHE_AUDIO_PROGRESS_ID
+                )
+
+        self.assertEqual(observed_states[0]['status'], 'downloading')
+        self.assertEqual(observed_states[0]['percent'], 25)
+        self.assertEqual(final_state['status'], 'ready')
+        self.assertEqual(final_state['downloaded_bytes'], len(b'complete audio'))
+
+    def test_cache_progress_persists_ffmpeg_encoding_state(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            with (
+                patch.object(addons, 'get_data_dir', return_value=data_dir),
+                patch.object(addons, 'get_ready_cached_video', return_value=None),
+            ):
+                progress = addons.DownloadProgress('https://example.com/video', 'cache-720')
+                progress.encoding()
+                state = addons.read_video_cache_progress('https://example.com/video', '720')
+
+        self.assertEqual(state['status'], 'encoding')
+        self.assertEqual(state['percent'], 100)
+
+    def test_repeated_cache_start_requests_launch_one_worker(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            with (
+                patch.object(addons, 'get_data_dir', return_value=data_dir),
+                patch.object(addons, 'get_ready_cached_video', return_value=None),
+                patch.object(addons, 'Thread', DeferredThread),
+            ):
+                first = addons.ensure_video_cache('https://example.com/video', '720')
+                second = addons.ensure_video_cache('https://example.com/video', '720')
+
+        self.assertEqual(first['status'], 'preparing')
+        self.assertEqual(second['status'], 'preparing')
+        self.assertEqual(len(DeferredThread.instances), 1)
+        self.assertTrue(DeferredThread.instances[0].started)
+        self.assertTrue(DeferredThread.instances[0].daemon)
+
+    def test_existing_progress_is_queried_without_resuming_cache_job(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            with (
+                patch.object(addons, 'get_data_dir', return_value=data_dir),
+                patch.object(addons, 'get_ready_cached_video', return_value=None),
+            ):
+                progress = addons.DownloadProgress('https://example.com/video', 'cache-720')
+                progress.error('previous job failed')
+
+                with patch.object(addons, 'ensure_video_cache') as ensure_video_cache:
+                    state = addons.start_video_cache_if_new('https://example.com/video', '720')
+
+        ensure_video_cache.assert_not_called()
+        self.assertEqual(state['status'], 'error')
+
+    def test_brand_new_cache_state_starts_background_job(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            expected = addons.DownloadProgress.initial_state()
+            with (
+                patch.object(addons, 'get_data_dir', return_value=data_dir),
+                patch.object(addons, 'get_ready_cached_video', return_value=None),
+                patch.object(addons, 'ensure_video_cache', return_value=expected) as ensure_video_cache,
+            ):
+                state = addons.start_video_cache_if_new('https://example.com/video', '720')
+
+        ensure_video_cache.assert_called_once_with('https://example.com/video', '720')
+        self.assertEqual(state, expected)
+
+    def test_ready_state_is_derived_from_validated_cached_video(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            video_path = os.path.join(data_dir, 'video-720.mp4')
+            with open(video_path, 'wb') as video_file:
+                video_file.write(b'ready video')
+
+            with (
+                patch.object(addons, 'get_data_dir', return_value=data_dir),
+                patch.object(addons, 'get_ready_cached_video', return_value=video_path),
+            ):
+                state = addons.read_video_cache_progress('https://example.com/video', '720')
+
+        self.assertEqual(state['status'], 'ready')
+        self.assertEqual(state['downloaded_bytes'], len(b'ready video'))
+        self.assertEqual(state['total_bytes'], len(b'ready video'))
+
+    def test_download_waiter_uses_existing_canonical_cache_job(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            video_path = os.path.join(data_dir, 'video-720.mp4')
+            progress_state = {
+                'status': 'downloading',
+                'percent': 50,
+                'downloaded_bytes': 50,
+                'total_bytes': 100,
+                'speed': 10,
+            }
+
+            def finish_cache(_seconds):
+                with open(video_path, 'wb') as video_file:
+                    video_file.write(b'ready video')
+
+            with (
+                patch.object(addons, 'get_data_dir', return_value=data_dir),
+                patch.object(addons, 'ensure_video_cache', return_value=progress_state) as ensure_video_cache,
+                patch.object(
+                    addons,
+                    'get_ready_cached_video',
+                    side_effect=[None, video_path],
+                ),
+                patch.object(addons, 'read_video_cache_progress', return_value=progress_state),
+                patch.object(addons.time, 'sleep', side_effect=finish_cache),
+            ):
+                result = addons.wait_for_video_cache(
+                    'https://example.com/video',
+                    '720',
+                    max_attempts=2,
+                    retry_interval=0,
+                )
+
+        ensure_video_cache.assert_called_once_with('https://example.com/video', '720')
+        self.assertEqual(result, video_path)
+
+
+class CacheProgressEndpointTests(unittest.TestCase):
+    def setUp(self):
+        app_module.app.config['TESTING'] = True
+        self.client = app_module.app.test_client()
+
+    def test_cache_progress_endpoint_returns_persistent_state(self):
+        state = {
+            'status': 'downloading',
+            'percent': 50,
+            'downloaded_bytes': 50,
+            'total_bytes': 100,
+            'speed': 10,
+        }
+        with patch.object(app_module, 'read_video_cache_progress', return_value=state):
+            response = self.client.get(
+                '/cache-progress?url=https%3A%2F%2Fexample.com%2Fvideo&quality=720'
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), state)
+        self.assertEqual(response.headers.get('Cache-Control'), 'no-store')
+
+    def test_cache_start_rejects_unsafe_quality(self):
+        response = self.client.post(
+            '/cache?url=https%3A%2F%2Fexample.com%2Fvideo&quality=..%2F..%2Fvideo'
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_sse_starts_cache_once_and_streams_changed_states_until_ready(self):
+        downloading = {
+            'status': 'downloading',
+            'percent': 25,
+            'downloaded_bytes': 25,
+            'total_bytes': 100,
+            'speed': 5,
+        }
+        ready = {
+            'status': 'ready',
+            'percent': 100,
+            'downloaded_bytes': 100,
+            'total_bytes': 100,
+            'speed': 0,
+        }
+
+        with (
+            patch.object(app_module, 'start_video_cache_if_new') as start_video_cache_if_new,
+            patch.object(
+                app_module,
+                'read_video_cache_progress',
+                side_effect=[downloading, downloading, ready],
+            ),
+            patch.object(app_module.time, 'sleep'),
+        ):
+            response = self.client.get(
+                '/cache-progress-stream?url=https%3A%2F%2Fexample.com%2Fvideo&quality=720'
+            )
+            body = response.get_data(as_text=True)
+
+        start_video_cache_if_new.assert_called_once_with('https://example.com/video', '720')
+        events = [
+            json.loads(line.removeprefix('data: '))
+            for line in body.splitlines()
+            if line.startswith('data: ')
+        ]
+        self.assertEqual(events, [downloading, ready])
+        self.assertEqual(response.mimetype, 'text/event-stream')
+        self.assertEqual(response.headers.get('Cache-Control'), 'no-cache, no-transform')
+        self.assertEqual(response.headers.get('X-Accel-Buffering'), 'no')
+
+    def test_sse_rejects_unsafe_quality_before_opening_stream(self):
+        response = self.client.get(
+            '/cache-progress-stream?url=https%3A%2F%2Fexample.com%2Fvideo&quality=invalid'
+        )
+        self.assertEqual(response.status_code, 400)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_cache_progress.py
+++ b/tests/test_cache_progress.py
@@ -29,7 +29,7 @@ class DeferredThread:
         self.started = True
 
 
-class CacheProgressStoreTests(unittest.TestCase):
+class DownloadProgressPersistenceTests(unittest.TestCase):
     def test_progress_state_is_written_with_atomic_replace(self):
         state = {
             'status': 'downloading',
@@ -44,24 +44,35 @@ class CacheProgressStoreTests(unittest.TestCase):
                 patch.object(addons, 'get_data_dir', return_value=data_dir),
                 patch.object(addons.os, 'replace', wraps=os.replace) as replace,
             ):
-                store = addons.CacheProgressStore('https://example.com/video', 'cache-720')
-                store.write(state)
+                progress = addons.DownloadProgress(
+                    'https://example.com/video', 'cache-720'
+                )
+                progress.state.update(state)
+                progress.start()
 
-                self.assertEqual(store.read(), state)
+                persisted_state = addons.DownloadProgress.read(
+                    'https://example.com/video', 'cache-720'
+                )
+                self.assertEqual(
+                    {key: persisted_state[key] for key in state},
+                    state,
+                )
                 replace.assert_called_once()
                 temp_path, destination = replace.call_args.args
-                self.assertEqual(destination, store.path)
+                self.assertEqual(destination, progress.path)
                 self.assertFalse(os.path.exists(temp_path))
 
     def test_invalid_progress_id_is_not_read_or_written(self):
         with tempfile.TemporaryDirectory() as data_dir:
             with patch.object(addons, 'get_data_dir', return_value=data_dir):
-                store = addons.CacheProgressStore(
+                progress = addons.DownloadProgress(
                     'https://example.com/video', '../../unsafe'
                 )
-                store.write({'status': 'ready'})
+                progress.ready(100)
 
-                self.assertIsNone(store.read())
+                self.assertIsNone(addons.DownloadProgress.read(
+                    'https://example.com/video', '../../unsafe'
+                ))
                 self.assertEqual(os.listdir(data_dir), [])
 
 
@@ -142,9 +153,9 @@ class CacheProgressTests(unittest.TestCase):
                     'status': 'started',
                     'postprocessor': 'FixupM3u8',
                 })
-                state = addons.CacheProgressStore(
+                state = addons.DownloadProgress.read(
                     'https://example.com/video', 'cache-720'
-                ).read()
+                )
 
         self.assertEqual(state['status'], 'downloading')
         self.assertEqual(state['percent'], 100)
@@ -168,9 +179,9 @@ class CacheProgressTests(unittest.TestCase):
                     'total_bytes': 20_000_000,
                     'speed': 2_000_000,
                 })
-                observed_states.append(addons.CacheProgressStore(
+                observed_states.append(addons.DownloadProgress.read(
                     downloader.url, addons.CACHE_AUDIO_PROGRESS_ID
-                ).read())
+                ))
                 with open(os.path.join(data_dir, 'audio.mp3'), 'wb') as audio_file:
                     audio_file.write(b'complete audio')
 
@@ -179,9 +190,9 @@ class CacheProgressTests(unittest.TestCase):
                 patch.object(addons.YTDLP, 'download', side_effect=download_audio),
             ):
                 downloader.audio()
-                final_state = addons.CacheProgressStore(
+                final_state = addons.DownloadProgress.read(
                     downloader.url, addons.CACHE_AUDIO_PROGRESS_ID
-                ).read()
+                )
 
         self.assertEqual(observed_states[0]['status'], 'downloading')
         self.assertEqual(observed_states[0]['percent'], 25)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,71 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+SOURCE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
+if SOURCE_DIR not in sys.path:
+    sys.path.insert(0, SOURCE_DIR)
+
+import addons
+import app as app_module
+
+
+class DownloadEndpointTests(unittest.TestCase):
+    def setUp(self):
+        app_module.app.config['TESTING'] = True
+        self.client = app_module.app.test_client()
+
+    def test_current_quality_serves_ready_cache_without_reentering_downloader(self):
+        url = 'https://example.com/video'
+        with tempfile.TemporaryDirectory() as data_dir:
+            cached_video = os.path.join(data_dir, 'video-720.mp4')
+            with open(cached_video, 'wb') as video_file:
+                video_file.write(b'ready cached video')
+
+            with (
+                patch.object(addons, 'get_data_dir', return_value=data_dir),
+                patch.object(app_module, 'wait_for_video_cache', return_value=cached_video) as wait_for_video_cache,
+                patch.object(app_module, 'get_meta', return_value={'title': 'Test Video'}),
+                patch.object(app_module, 'MediaDownloader') as media_downloader,
+            ):
+                response = self.client.get(
+                    '/download?url=https%3A%2F%2Fexample.com%2Fvideo&quality=720'
+                )
+                progress = addons.DownloadProgress.read(url, 'cache-720')
+                response_data = response.get_data()
+                content_disposition = response.headers.get('Content-Disposition')
+                response.close()
+
+        media_downloader.assert_not_called()
+        wait_for_video_cache.assert_called_once_with(url, '720')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_data, b'ready cached video')
+        self.assertIn('Test Video-720.mp4', content_disposition)
+        self.assertEqual(progress['status'], 'ready')
+        self.assertEqual(progress['percent'], 100)
+        self.assertEqual(progress['downloaded_bytes'], len(b'ready cached video'))
+        self.assertEqual(progress['total_bytes'], len(b'ready cached video'))
+
+    def test_trim_waits_for_canonical_cache_before_deriving_download(self):
+        url = 'https://example.com/video'
+        with tempfile.NamedTemporaryFile(suffix='.mp4') as cached_video:
+            with (
+                patch.object(app_module, 'wait_for_video_cache', return_value=cached_video.name) as wait_for_video_cache,
+                patch.object(app_module, 'get_meta', return_value={'title': 'Test Video'}),
+                patch.object(app_module, 'host_file', return_value=app_module.Response('trimmed')) as host_file,
+            ):
+                response = self.client.get(
+                    '/download?url=https%3A%2F%2Fexample.com%2Fvideo&quality=720&start=10&end=20'
+                )
+
+        wait_for_video_cache.assert_called_once_with(url, '720')
+        host_file.assert_called_once()
+        self.assertEqual(host_file.call_args.args[:2], (url, 'video-720_10.0-20.0'))
+        self.assertEqual(response.data, b'trimmed')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -25,7 +25,8 @@ class DownloadEndpointTests(unittest.TestCase):
                 video_file.write(b'ready cached video')
 
             with (
-                patch.object(app_module, 'wait_for_video_cache', return_value=cached_video) as wait_for_video_cache,
+                patch.object(app_module, 'ensure_video_cache', return_value={'status': 'ready'}) as ensure_video_cache,
+                patch.object(app_module, 'get_ready_cached_video', return_value=cached_video) as get_ready_cached_video,
                 patch.object(app_module, 'get_meta', return_value={'title': 'Test Video'}),
                 patch.object(app_module, 'MediaDownloader') as media_downloader,
             ):
@@ -37,7 +38,8 @@ class DownloadEndpointTests(unittest.TestCase):
                 response.close()
 
         media_downloader.assert_not_called()
-        wait_for_video_cache.assert_called_once_with(url, '720')
+        ensure_video_cache.assert_called_once_with(url, '720')
+        get_ready_cached_video.assert_called_once_with(url, '720', validate=False)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response_data, b'ready cached video')
         self.assertIn('Test Video-720.mp4', content_disposition)
@@ -46,7 +48,8 @@ class DownloadEndpointTests(unittest.TestCase):
         url = 'https://example.com/video'
         with tempfile.NamedTemporaryFile(suffix='.mp4') as cached_video:
             with (
-                patch.object(app_module, 'wait_for_video_cache', return_value=cached_video.name) as wait_for_video_cache,
+                patch.object(app_module, 'ensure_video_cache', return_value={'status': 'ready'}) as ensure_video_cache,
+                patch.object(app_module, 'get_ready_cached_video', return_value=cached_video.name),
                 patch.object(app_module, 'get_meta', return_value={'title': 'Test Video'}),
                 patch.object(app_module, 'host_file', return_value=app_module.Response('trimmed')) as host_file,
             ):
@@ -54,7 +57,7 @@ class DownloadEndpointTests(unittest.TestCase):
                     '/download?url=https%3A%2F%2Fexample.com%2Fvideo&quality=720&start=10&end=20'
                 )
 
-        wait_for_video_cache.assert_called_once_with(url, '720')
+        ensure_video_cache.assert_called_once_with(url, '720')
         host_file.assert_called_once()
         self.assertEqual(host_file.call_args.args[:2], (url, 'video-720_10.0-20.0'))
         self.assertEqual(response.data, b'trimmed')
@@ -62,7 +65,7 @@ class DownloadEndpointTests(unittest.TestCase):
     def test_audio_download_bypasses_video_cache(self):
         url = 'https://example.com/video'
         with (
-            patch.object(app_module, 'wait_for_video_cache') as wait_for_video_cache,
+            patch.object(app_module, 'ensure_video_cache') as ensure_video_cache,
             patch.object(app_module, 'get_meta', return_value={'title': 'Test Video'}),
             patch.object(app_module, 'host_file', return_value=app_module.Response('audio')) as host_file,
         ):
@@ -70,9 +73,35 @@ class DownloadEndpointTests(unittest.TestCase):
                 '/download?url=https%3A%2F%2Fexample.com%2Fvideo&quality=audio'
             )
 
-        wait_for_video_cache.assert_not_called()
+        ensure_video_cache.assert_not_called()
         host_file.assert_called_once_with(url, 'audio', download_name='Test Video')
         self.assertEqual(response.data, b'audio')
+
+    def test_in_progress_cache_returns_immediately_without_a_file(self):
+        state = {
+            'status': 'downloading',
+            'percent': 50,
+            'downloaded_bytes': 50,
+            'total_bytes': 100,
+            'speed': 10,
+        }
+        with (
+            patch.object(app_module, 'ensure_video_cache', return_value=state) as ensure_video_cache,
+            patch.object(app_module, 'get_ready_cached_video') as get_ready_cached_video,
+            patch.object(app_module, 'host_file') as host_file,
+        ):
+            response = self.client.get(
+                '/download?url=https%3A%2F%2Fexample.com%2Fvideo&quality=720'
+            )
+
+        ensure_video_cache.assert_called_once_with('https://example.com/video', '720')
+        get_ready_cached_video.assert_not_called()
+        host_file.assert_not_called()
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.data, b'')
+        self.assertEqual(response.headers.get('X-Cache-Status'), 'downloading')
+        self.assertEqual(response.headers.get('Retry-After'), '1')
+        self.assertEqual(response.headers.get('Cache-Control'), 'no-store')
 
 
 if __name__ == '__main__':

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -9,7 +9,6 @@ SOURCE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'
 if SOURCE_DIR not in sys.path:
     sys.path.insert(0, SOURCE_DIR)
 
-import addons
 import app as app_module
 
 
@@ -26,7 +25,6 @@ class DownloadEndpointTests(unittest.TestCase):
                 video_file.write(b'ready cached video')
 
             with (
-                patch.object(addons, 'get_data_dir', return_value=data_dir),
                 patch.object(app_module, 'wait_for_video_cache', return_value=cached_video) as wait_for_video_cache,
                 patch.object(app_module, 'get_meta', return_value={'title': 'Test Video'}),
                 patch.object(app_module, 'MediaDownloader') as media_downloader,
@@ -34,7 +32,6 @@ class DownloadEndpointTests(unittest.TestCase):
                 response = self.client.get(
                     '/download?url=https%3A%2F%2Fexample.com%2Fvideo&quality=720'
                 )
-                progress = addons.DownloadProgress.read(url, 'cache-720')
                 response_data = response.get_data()
                 content_disposition = response.headers.get('Content-Disposition')
                 response.close()
@@ -44,10 +41,6 @@ class DownloadEndpointTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response_data, b'ready cached video')
         self.assertIn('Test Video-720.mp4', content_disposition)
-        self.assertEqual(progress['status'], 'ready')
-        self.assertEqual(progress['percent'], 100)
-        self.assertEqual(progress['downloaded_bytes'], len(b'ready cached video'))
-        self.assertEqual(progress['total_bytes'], len(b'ready cached video'))
 
     def test_trim_waits_for_canonical_cache_before_deriving_download(self):
         url = 'https://example.com/video'
@@ -65,6 +58,21 @@ class DownloadEndpointTests(unittest.TestCase):
         host_file.assert_called_once()
         self.assertEqual(host_file.call_args.args[:2], (url, 'video-720_10.0-20.0'))
         self.assertEqual(response.data, b'trimmed')
+
+    def test_audio_download_bypasses_video_cache(self):
+        url = 'https://example.com/video'
+        with (
+            patch.object(app_module, 'wait_for_video_cache') as wait_for_video_cache,
+            patch.object(app_module, 'get_meta', return_value={'title': 'Test Video'}),
+            patch.object(app_module, 'host_file', return_value=app_module.Response('audio')) as host_file,
+        ):
+            response = self.client.get(
+                '/download?url=https%3A%2F%2Fexample.com%2Fvideo&quality=audio'
+            )
+
+        wait_for_video_cache.assert_not_called()
+        host_file.assert_called_once_with(url, 'audio', download_name='Test Video')
+        self.assertEqual(response.data, b'audio')
 
 
 if __name__ == '__main__':

--- a/tests/test_media_compatibility.py
+++ b/tests/test_media_compatibility.py
@@ -88,15 +88,16 @@ class CachedMediaCompatibilityTests(unittest.TestCase):
 
     def test_active_cache_job_is_never_used_for_playback(self):
         with tempfile.TemporaryDirectory() as data_dir:
-            lock_path = os.path.join(data_dir, 'video-720.temp')
-            with open(lock_path, 'w') as lock_file:
-                lock_file.write('active')
-
             with (
                 patch.object(addons, 'get_data_dir', return_value=data_dir),
                 patch.object(addons, 'check_media') as check_media,
             ):
-                self.assertIsNone(addons.get_ready_cached_video('https://example.com/video', '720'))
+                lock_store = addons.CacheLockStore('https://example.com/video', 'video-720')
+                self.assertTrue(lock_store.try_acquire_media_lock())
+                try:
+                    self.assertIsNone(addons.get_ready_cached_video('https://example.com/video', '720'))
+                finally:
+                    lock_store.release_media_lock()
             check_media.assert_not_called()
 
 

--- a/tests/test_media_compatibility.py
+++ b/tests/test_media_compatibility.py
@@ -1,0 +1,104 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+SOURCE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
+if SOURCE_DIR not in sys.path:
+    sys.path.insert(0, SOURCE_DIR)
+
+import addons
+
+
+class CachedMediaCompatibilityTests(unittest.TestCase):
+    @staticmethod
+    def probe_result(*streams):
+        return subprocess.CompletedProcess(
+            args=['ffprobe'],
+            returncode=0,
+            stdout=json.dumps({'streams': list(streams)}),
+            stderr='',
+        )
+
+    def test_mp3_audio_in_mp4_is_rejected(self):
+        result = self.probe_result(
+            {'codec_type': 'video', 'codec_name': 'h264'},
+            {'codec_type': 'audio', 'codec_name': 'mp3'},
+        )
+        with (
+            patch.object(addons.shutil, 'which', return_value='/usr/bin/ffprobe'),
+            patch.object(addons.subprocess, 'run', return_value=result),
+        ):
+            self.assertFalse(addons.is_compatible_cached_media('/cache/video-720.mp4', 'video-720'))
+
+    def test_aac_audio_in_mp4_is_accepted(self):
+        result = self.probe_result(
+            {'codec_type': 'video', 'codec_name': 'h264'},
+            {'codec_type': 'audio', 'codec_name': 'aac'},
+        )
+        with (
+            patch.object(addons.shutil, 'which', return_value='/usr/bin/ffprobe'),
+            patch.object(addons.subprocess, 'run', return_value=result),
+        ):
+            self.assertTrue(addons.is_compatible_cached_media('/cache/video-720.mp4', 'video-720'))
+
+    def test_video_only_mp4_is_rejected(self):
+        result = self.probe_result({'codec_type': 'video', 'codec_name': 'h264'})
+        with (
+            patch.object(addons.shutil, 'which', return_value='/usr/bin/ffprobe'),
+            patch.object(addons.subprocess, 'run', return_value=result),
+        ):
+            self.assertFalse(addons.is_compatible_cached_media('/cache/video-720.mp4', 'video-720'))
+
+    def test_non_video_cache_does_not_invoke_ffprobe(self):
+        with patch.object(addons.subprocess, 'run') as run:
+            self.assertTrue(addons.is_compatible_cached_media('/cache/audio.mp3', 'audio'))
+        run.assert_not_called()
+
+    def test_ready_cached_video_requires_video_and_audio(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            video_path = os.path.join(data_dir, 'video-720.mp4')
+            with open(video_path, 'wb') as video_file:
+                video_file.write(b'media')
+
+            streams = [
+                {'codec_type': 'video', 'codec_name': 'h264'},
+                {'codec_type': 'audio', 'codec_name': 'aac'},
+            ]
+            with (
+                patch.object(addons, 'get_data_dir', return_value=data_dir),
+                patch.object(addons, 'check_media', return_value=video_path),
+                patch.object(addons, 'probe_media_streams', return_value=streams),
+            ):
+                self.assertEqual(
+                    addons.get_ready_cached_video('https://example.com/video', '720'),
+                    video_path,
+                )
+
+            with (
+                patch.object(addons, 'get_data_dir', return_value=data_dir),
+                patch.object(addons, 'check_media', return_value=video_path),
+                patch.object(addons, 'probe_media_streams', return_value=streams[:1]),
+            ):
+                self.assertIsNone(addons.get_ready_cached_video('https://example.com/video', '720'))
+
+    def test_active_cache_job_is_never_used_for_playback(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            lock_path = os.path.join(data_dir, 'video-720.temp')
+            with open(lock_path, 'w') as lock_file:
+                lock_file.write('active')
+
+            with (
+                patch.object(addons, 'get_data_dir', return_value=data_dir),
+                patch.object(addons, 'check_media') as check_media,
+            ):
+                self.assertIsNone(addons.get_ready_cached_video('https://example.com/video', '720'))
+            check_media.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_playback_source.py
+++ b/tests/test_playback_source.py
@@ -1,0 +1,86 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from flask import Response
+
+
+SOURCE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
+if SOURCE_DIR not in sys.path:
+    sys.path.insert(0, SOURCE_DIR)
+
+import app as app_module
+
+
+class PlaybackSourceTests(unittest.TestCase):
+    def setUp(self):
+        app_module.app.config['TESTING'] = True
+        self.client = app_module.app.test_client()
+
+    def test_direct_uses_ready_local_video(self):
+        with tempfile.NamedTemporaryFile(suffix='.mp4') as video_file:
+            video_file.write(b'cached video')
+            video_file.flush()
+            with patch.object(app_module, 'get_ready_cached_video', return_value=video_file.name):
+                response = self.client.head('/direct?url=https%3A%2F%2Fexample.com%2Fvideo&quality=720')
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.headers.get('X-Playback-Source'), 'local')
+            self.assertEqual(response.headers.get('Accept-Ranges'), 'bytes')
+            response.close()
+
+    def test_direct_stream_preference_never_checks_the_video_cache(self):
+        with patch.object(app_module, 'get_ready_cached_video') as get_ready_cached_video:
+            response = self.client.head(
+                '/direct?url=https%3A%2F%2Fexample.com%2Fvideo&quality=720&playback=stream'
+            )
+
+        get_ready_cached_video.assert_not_called()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get('X-Playback-Source'), 'stream')
+
+    def test_first_stream_request_proxies_a_new_url_descriptor(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.url') as descriptor:
+            descriptor.write('https://cdn.example/video.mp4\n{\"User-Agent\": \"test\"}\nsession=value\n')
+            descriptor.flush()
+            downloader = MagicMock()
+            downloader.run.return_value = descriptor.name
+
+            with (
+                patch.object(app_module, 'check_media', return_value=None),
+                patch.object(app_module, 'MediaDownloader', return_value=downloader),
+                patch.object(app_module, 'stream_media_file', return_value=Response('stream')) as stream_media_file,
+            ):
+                response = self.client.get(
+                    '/direct?url=https%3A%2F%2Fexample.com%2Fvideo&quality=720&playback=stream'
+                )
+
+        stream_media_file.assert_called_once_with(
+            'https://example.com/video',
+            'https://cdn.example/video.mp4',
+            '{"User-Agent": "test"}',
+            'session=value',
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get('X-Playback-Source'), 'stream')
+
+    def test_local_playback_supports_byte_ranges_for_seeking(self):
+        with tempfile.NamedTemporaryFile(suffix='.mp4') as video_file:
+            video_file.write(b'0123456789')
+            video_file.flush()
+            with patch.object(app_module, 'get_ready_cached_video', return_value=video_file.name):
+                response = self.client.get(
+                    '/direct?url=https%3A%2F%2Fexample.com%2Fvideo&quality=720&playback=local',
+                    headers={'Range': 'bytes=2-5'},
+                )
+
+            self.assertEqual(response.status_code, 206)
+            self.assertEqual(response.data, b'2345')
+            self.assertEqual(response.headers.get('Content-Range'), 'bytes 2-5/10')
+            self.assertEqual(response.headers.get('X-Playback-Source'), 'local')
+            response.close()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_stream_proxy.py
+++ b/tests/test_stream_proxy.py
@@ -1,0 +1,90 @@
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
+
+
+SOURCE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src'))
+if SOURCE_DIR not in sys.path:
+    sys.path.insert(0, SOURCE_DIR)
+
+import addons
+from app import app
+
+
+class StreamProxyTests(unittest.TestCase):
+    def test_relative_hls_segments_resolve_against_final_playlist_url(self):
+        upstream = MagicMock()
+        upstream.status_code = 200
+        upstream.headers = {'Content-Type': 'application/vnd.apple.mpegurl'}
+        upstream.content = b'#EXTM3U\n#EXTINF:5.0,\nsegments/part-001.ts\n'
+        upstream.url = 'https://cdn.example/media/master/playlist.m3u8?token=abc'
+        upstream.raise_for_status.return_value = None
+
+        with (
+            app.test_request_context('/external'),
+            patch.object(addons.requests, 'get', return_value=upstream),
+        ):
+            response = addons.stream_media_file(
+                'https://video.example/watch/123',
+                'https://redirect.example/playlist.m3u8',
+                '{"User-Agent": "test"}',
+                'session=value',
+            )
+
+        segment_line = response.get_data(as_text=True).splitlines()[-1]
+        query = parse_qs(urlparse(segment_line).query)
+        self.assertEqual(
+            query['src'][0],
+            'https://cdn.example/media/master/segments/part-001.ts',
+        )
+
+    def test_relative_hls_tag_uris_use_the_same_playlist_base(self):
+        upstream = MagicMock()
+        upstream.status_code = 200
+        upstream.headers = {'Content-Type': 'application/x-mpegURL'}
+        upstream.content = b'#EXTM3U\n#EXT-X-MAP:URI="init/video.mp4"\nsegment.ts\n'
+        upstream.url = 'https://cdn.example/path/playlist.m3u8'
+        upstream.raise_for_status.return_value = None
+
+        with (
+            app.test_request_context('/external'),
+            patch.object(addons.requests, 'get', return_value=upstream),
+        ):
+            response = addons.stream_media_file(
+                'https://video.example/watch/123',
+                'https://cdn.example/path/playlist.m3u8',
+            )
+
+        playlist = response.get_data(as_text=True)
+        self.assertIn(
+            'src=https%3A%2F%2Fcdn.example%2Fpath%2Finit%2Fvideo.mp4',
+            playlist,
+        )
+
+    def test_mislabeled_m3u8_playlist_is_still_rewritten(self):
+        upstream = MagicMock()
+        upstream.status_code = 200
+        upstream.headers = {'Content-Type': 'application/octet-stream'}
+        upstream.content = b'#EXTM3U\nsegment.ts\n'
+        upstream.url = 'https://cdn.example/path/playlist.m3u8?token=abc'
+        upstream.raise_for_status.return_value = None
+
+        with (
+            app.test_request_context('/external'),
+            patch.object(addons.requests, 'get', return_value=upstream),
+        ):
+            response = addons.stream_media_file(
+                'https://video.example/watch/123',
+                upstream.url,
+            )
+
+        self.assertIn(
+            'src=https%3A%2F%2Fcdn.example%2Fpath%2Fsegment.ts',
+            response.get_data(as_text=True),
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Context
Historically videos are optimistically cached when a user opens a video, whilst a streamed version of the video source is provided to the web player. This approach had some problems, which includes degraded streaming performance by streaming remotely instead of streaming directly from the cache (especially noticeable on slower networks), multiple unnecessary YTDLP download attempts instead of waiting for the cache to hydrate, and a lack of real-time progress report for the end user. In addition, there were some race conditions due to bugs in the code that led to multiple caching jobs being started simultaneously. 

The new approach revamps the model behind video caching and playback, instantiating a canonical video cache job per video source and using remote streaming whilst the cache is being hydrated. Once hydrated, the locally cached video is used for playback and downloading. A new progress bar is added to the UI so the user can be kept up to date on the cache (effectively download) progression, which is persisted across browser sessions and backed by the server itself.

### Main changes

- Added DownloadProgress and a new SSE endpoint to stream cache/download progression updates to the front-end.
- Numerous new helper method to query and start new cache jobs for videos, and return local cached videos on completion.
- Fixed race condition with file locks.
- New progress bar in the UI displaying real time cache/download progression.
- Added tests.